### PR TITLE
Fix for new string implementation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.5
+Compat 0.10.0
 DataStreams 0.1.0
 DataFrames
 WeakRefStrings 0.1.3

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 module CSV
 
-using DataStreams, DataFrames, WeakRefStrings
+using Compat, DataStreams, DataFrames, WeakRefStrings
 
 export Data, DataFrame
 

--- a/src/Sink.jl
+++ b/src/Sink.jl
@@ -70,7 +70,7 @@ end
 
 function Data.close!(sink::CSV.Sink)
     io = isa(sink.fullpath, AbstractString) ? open(sink.fullpath, sink.append ? "a" : "w") : sink.fullpath
-    Base.write(io, takebuf_array(sink.io))
+    Base.write(io, take!(sink.io))
     applicable(close, io) && close(io)
     return nothing
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -33,7 +33,7 @@ function readline(io::IO, q::UInt8, e::UInt8, buf::IOBuffer=IOBuffer())
             break
         end
     end
-    return takebuf_string(buf)
+    return String(take!(buf))
 end
 readline(io::IO, q='"', e='\\', buf::IOBuffer=IOBuffer()) = readline(io, UInt8(q), UInt8(e), buf)
 readline(source::CSV.Source) = readline(source.io, source.options.quotechar, source.options.escapechar)
@@ -66,7 +66,7 @@ function readsplitline(io::IO, d::UInt8, q::UInt8, e::UInt8, buf::IOBuffer=IOBuf
                 end
             end
         elseif b == d
-            push!(vals,takebuf_string(buf))
+            push!(vals,String(take!(buf)))
         elseif b == NEWLINE
             break
         elseif b == RETURN
@@ -76,7 +76,7 @@ function readsplitline(io::IO, d::UInt8, q::UInt8, e::UInt8, buf::IOBuffer=IOBuf
             Base.write(buf, b)
         end
     end
-    return push!(vals,takebuf_string(buf))
+    return push!(vals,String(take!(buf)))
 end
 readsplitline(io::IO, d=',', q='"', e='\\', buf::IOBuffer=IOBuffer()) = readsplitline(io, UInt8(d), UInt8(q), UInt8(e), buf)
 readsplitline(source::CSV.Source) = readsplitline(source.io, source.options.delim, source.options.quotechar, source.options.escapechar)


### PR DESCRIPTION
Avoid explicit access to the `data` field and stop using `takebuf_array` and `takebuf_string`. This requires a dependency on `Compat`.