### PR TITLE
loosen Compat requirement to 0.9.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-Compat 0.10.0
+Compat 0.9.5
 DataStreams 0.1.0
 DataFrames
 WeakRefStrings 0.1.3


### PR DESCRIPTION
`take!` was introduced in 0.9.5, `transcode` and `.=` in 0.10.0 (https://github.com/JuliaLang/Compat.jl/compare/v0.9.5...v0.10.0)
but neither of those are used here