### PR TITLE
Fix error on empty CSV with header and transforms

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -292,6 +292,10 @@ function read end
 
 function read(fullpath::Union{AbstractString,IO}, sink=DataFrame, args...; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
     source = Source(fullpath; kwargs...)
+    if source.schema.rows == 0
+        # If the source is empty, ignore transforms to prevent type conversion errors.
+        transforms = Dict{Int,Function}()
+    end
     sink = Data.stream!(source, sink, append, transforms, args...)
     Data.close!(sink)
     return sink
@@ -299,6 +303,10 @@ end
 
 function read{T}(fullpath::Union{AbstractString,IO}, sink::T; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
     source = Source(fullpath; kwargs...)
+    if source.schema.rows == 0
+        # If the source is empty, ignore transforms to prevent type conversion errors.
+        transforms = Dict{Int,Function}()
+    end
     sink = Data.stream!(source, sink, append, transforms)
     Data.close!(sink)
     return sink

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -290,7 +290,7 @@ sq1 = CSV.read(source, SQLite.Sink, db, "sqlite_table")
 """
 function read end
 
-function read(fullpath::Union{AbstractString,IO}, sink=DataFrame, args...; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
+function read(fullpath::Union{AbstractString,IO}, sink::Type=DataFrame, args...; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
     source = Source(fullpath; kwargs...)
     if source.schema.rows == 0
         # If the source is empty, ignore transforms to prevent type conversion errors.

--- a/test/source.jl
+++ b/test/source.jl
@@ -336,3 +336,17 @@ df2 = CSV.read(IOBuffer(""); header=["a", "b", "c"])
 @test size(df1) == (0, 3)
 @test size(df2) == (0, 3)
 @test df1 == df2
+
+# Adding transforms to CSV with header but no data returns empty frame as expected
+# (previously the lack of a ::String dispatch in the transform function caused an error)
+transforms = Dict{Int, Function}(2 => x::Integer -> "b$x")
+df1 = CSV.read(IOBuffer("a,b,c\n1,2,3\n4,5,6"); nullable=false, transforms=transforms)
+df2 = CSV.read(IOBuffer("a,b,c\n1,b2,3\n4,b5,6"); nullable=false)
+@test size(df1) == (2, 3)
+@test size(df2) == (2, 3)
+@test df1 == df2
+df3 = CSV.read(IOBuffer("a,b,c"); nullable=false, transforms=transforms)
+df4 = CSV.read(IOBuffer("a,b,c"); nullable=false)
+@test size(df3) == (0, 3)
+@test size(df4) == (0, 3)
+@test df3 == df4

--- a/test/source.jl
+++ b/test/source.jl
@@ -350,3 +350,15 @@ df4 = CSV.read(IOBuffer("a,b,c"); nullable=false)
 @test size(df3) == (0, 3)
 @test size(df4) == (0, 3)
 @test df3 == df4
+
+let fn = tempname()
+    df = CSV.read(IOBuffer("a,b,c\n1,2,3\n4,5,6"), CSV.Sink(fn); nullable=false, transforms=transforms)
+    @test readstring(fn) == "\"a\",\"b\",\"c\"\n1,\"b2\",3\n4,\"b5\",6\n"
+    rm(fn)
+end
+
+let fn = tempname()
+    df = CSV.read(IOBuffer("a,b,c"), CSV.Sink(fn); nullable=false, transforms=transforms)
+    @test readstring(fn) == "\"a\",\"b\",\"c\"\n"
+    rm(fn)
+end


### PR DESCRIPTION
This was specifically an issue when the transforms dictionary included
functions that didn't have known return values for `String` inputs and
when there was a header row but no data (or when the buffer was empty
but a header was specified). `DataStreams.transform` attempted to infer
a return type for the function and got back `Union{}`, which errored.

Closes #74