### PR TITLE
Fix bug causing `CSV.read` to incorrectly see some streams as empty

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -56,8 +56,8 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         fullpath = "<IOBuffer>"
         fs = nb_available(source)
     elseif isa(fullpath, IO)
-        fs = nb_available(fullpath)
         source = IOBuffer(Base.read(fullpath))
+        fs = nb_available(source)
         fullpath = isdefined(fullpath, :name) ? fullpath.name : "__IO__"
     else
         source = open(fullpath, "r") do f

--- a/test/multistream.jl
+++ b/test/multistream.jl
@@ -1,0 +1,48 @@
+# Previous versions assumed that nb_available could accurately check for an empty CSV, but
+# this doesn't work reliably for streams because nb_available only checks buffered bytes
+# (see issue #77). This test verifies that even when nb_available would return 0 on a stream
+# the full stream is still read.
+
+type MultiStream{S<:IO} <: IO
+    streams::Array{S}
+    index::Int
+end
+
+function MultiStream{S<:IO}(streams::AbstractArray{S})
+    MultiStream(streams, 1)
+end
+
+function refill(s::MultiStream)
+    while eof(s.streams[s.index]) && s.index < length(s.streams)
+        close(s.streams[s.index])
+        s.index += 1
+    end
+end
+
+function Base.close(s::MultiStream)
+    for i in s.index:length(s.streams)
+        close(s.streams[i])
+    end
+    s.index = length(s.streams)
+    nothing
+end
+
+function Base.eof(s::MultiStream)
+    eof(s.streams[s.index]) && s.index == length(s.streams)
+end
+
+function Base.read(s::MultiStream, ::Type{UInt8})
+    refill(s)
+    read(s.streams[s.index], UInt8)::UInt8
+end
+
+function Base.nb_available(s::MultiStream)
+    nb_available(s.streams[s.index])
+end
+
+stream = MultiStream(
+    [IOBuffer(""), IOBuffer("a,b,c\n1,2,3\n"), IOBuffer(""), IOBuffer("4,5,6")]
+)
+
+@test nb_available(stream) == 0
+@test isequal(CSV.read(stream), CSV.read(IOBuffer("a,b,c\n1,2,3\n4,5,6")))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ dir = joinpath(dirname(@__FILE__),"test_files/")
 # dir = joinpath(Pkg.dir("CSV"), "test/test_files")
 
 include("source.jl")
+include("multistream.jl")
 
 using DataStreamsIntegrationTests
 


### PR DESCRIPTION
Previous versions assumed that nb_available could accurately check for an empty CSV, but
this doesn't work reliably for streams because nb_available only checks buffered bytes.

Closes #77.