### PR TITLE
Fix invalid escape sequence in docstring, update CI for 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 
 julia:
   - 0.5
+  - 0.6
   - nightly
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -23,7 +23,7 @@ julia> Pkg.add("CSV")
 
 ## Project Status
 
-The package is tested against Julia `0.4` and *current* `0.5` on Linux, OS X, and Windows.
+The package is tested against Julia `0.4`, `0.5`, and *current* `0.6` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
@@ -53,3 +53,5 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [pkg-0.4-url]: http://pkg.julialang.org/?pkg=CSV
 [pkg-0.5-img]: http://pkg.julialang.org/badges/CSV_0.5.svg
 [pkg-0.5-url]: http://pkg.julialang.org/?pkg=CSV
+[pkg-0.6-img]: http://pkg.julialang.org/badges/CSV_0.6.svg
+[pkg-0.6-url]: http://pkg.julialang.org/?pkg=CSV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -250,7 +250,7 @@ Other example invocations may include:
 # read in a tab-delimited file
 CSV.read(file; delim='\t')
 
-# read in a comma-delimited file with null values represented as '\N', such as a MySQL export
+# read in a comma-delimited file with null values represented as '\\N', such as a MySQL export
 CSV.read(file; null="\\N")
 
 # manually provided column names; must match # of columns of data in file


### PR DESCRIPTION
CSV won't load for me on 0.7-DEV. Adding the extra backslash in the docstring fixes the parsing. 

Not sure if the CI file updates are correct, but I presume `nightly` is now testing against 0.7-DEV rather than 0.6 so this is my best guess for how to add 0.6 CI support.