### PR TITLE
Correct `ind` in `WeakRefString` created by `parsefield`

### DIFF
--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -217,7 +217,7 @@ const NULLSTRING = Nullable{WeakRefString{UInt8}}()
         end
     end
     eof(io) && (state[] = EOF)
-    return (len == 0 || nullcheck) ? NULLSTRING : Nullable{WeakRefString{UInt8}}(WeakRefString(Ptr{UInt8}(ptr), len, ptr - start_ptr))
+    return (len == 0 || nullcheck) ? NULLSTRING : Nullable{WeakRefString{UInt8}}(WeakRefString(Ptr{UInt8}(ptr), len, ptr - start_ptr + 1))
 end
 
 function parsefield{T<:AbstractString}(io::IO, ::Type{T}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::Ref{ParsingState}=STATE)

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -798,6 +798,15 @@ io = IOBuffer("\"\\N\"")
 v = CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(null="\\N"),1,1)
 @test isnull(v)
 
+io = IOBuffer("test index")
+v = CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(),1,1)
+@test string(get(v)) == "test index"
+@test get(v).ind == 1
+seek(io, 5)
+v = CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(),1,1)
+@test string(get(v)) == "index"
+@test get(v).ind == 6
+
 # Libz
 io = ZlibInflateInputStream(ZlibDeflateInputStream(IOBuffer("0")))
 v = CSV.parsefield(io,String,CSV.Options(),1,1)


### PR DESCRIPTION
Previous versions of `parsefield(io, ::Type{WeakRefString{UInt8}}, ...)` appear to assume that `WeakRefString`'s index field (`ind`) is zero-indexed. This causes problems when this index is used to recreate the `WeakRefString`s when attempting to append two `NullableVector{WeakRefString}`s.

Closes #90