### PR TITLE
Fix #43 by supporting CategoricalArray parsing.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.9.5
 DataStreams 0.2.0
 DataFrames
 WeakRefStrings 0.3.0
+CategoricalArrays 0.2.0

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 module CSV
 
-using DataStreams, WeakRefStrings, Nulls, DataFrames
+using DataStreams, WeakRefStrings, Nulls, CategoricalArrays, DataFrames
 
 struct ParsingException <: Exception
     msg::String

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -14,6 +14,7 @@ function Source(fullpath::Union{AbstractString,IO};
               decimal=PERIOD,
               truestring="true",
               falsestring="false",
+              categorical::Bool=true,
 
               footerskip::Int=0,
               rows_for_type_detect::Int=20,
@@ -28,7 +29,7 @@ function Source(fullpath::Union{AbstractString,IO};
                                             quotechar=typeof(quotechar) <: String ? UInt8(first(quotechar)) : (quotechar % UInt8),
                                             escapechar=typeof(escapechar) <: String ? UInt8(first(escapechar)) : (escapechar % UInt8),
                                             null=null, dateformat=dateformat, decimal=decimal, truestring=truestring, falsestring=falsestring),
-                        header=header, datarow=datarow, types=types, nullable=nullable, footerskip=footerskip,
+                        header=header, datarow=datarow, types=types, nullable=nullable, categorical=categorical, footerskip=footerskip,
                         rows_for_type_detect=rows_for_type_detect, rows=rows, use_mmap=use_mmap)
 end
 
@@ -39,6 +40,7 @@ function Source(;fullpath::Union{AbstractString,IO}="",
                 datarow::Int=-1, # by default, data starts immediately after header or start of file
                 types=Type[],
                 nullable::Union{Bool, Null}=null,
+                categorical::Bool=true,
 
                 footerskip::Int=0,
                 rows_for_type_detect::Int=20,
@@ -131,6 +133,7 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         columntypes = types
     elseif isa(types, Dict) || isempty(types)
         columntypes = Vector{Type}(cols)
+        categoricals = Dict{Int, Set{String}}(i=>Set{String}() for i = 1:cols)
         fill!(columntypes, Any)
         lineschecked = 0
         while !eof(source) && lineschecked < min(rows < 0 ? rows_for_type_detect : rows, rows_for_type_detect)
@@ -138,7 +141,7 @@ function Source(;fullpath::Union{AbstractString,IO}="",
             # println("type detecting on row = $lineschecked...")
             for i = 1:cols
                 # print("\tdetecting col = $i...")
-                typ = CSV.detecttype(source, options, columntypes[i])::Type
+                typ = CSV.detecttype(source, options, columntypes[i], categoricals[i])::Type
                 # print(typ)
                 columntypes[i] = CSV.promote_type2(columntypes[i], typ)
                 # println("...promoting to: ", columntypes[i])
@@ -149,6 +152,13 @@ function Source(;fullpath::Union{AbstractString,IO}="",
             options = Options(delim=options.delim, quotechar=options.quotechar, escapechar=options.escapechar,
                               null=options.null, dateformat=Dates.ISODateTimeFormat, decimal=options.decimal,
                               datarow=options.datarow, rows=options.rows, header=options.header, types=options.types)
+        end
+        if categorical
+            for i = 1:cols
+                T = columntypes[i]
+                columntypes[i] = ifelse(length(categoricals[i]) / rows_for_type_detect < .9 && T <: WeakRefString,
+                    CategoricalValue{String, UInt16}, T)
+            end
         end
     else
         throw(ArgumentError("$cols number of columns detected; `types` argument has $(length(types)) entries"))
@@ -230,6 +240,7 @@ Keyword Arguments:
 * `append::Bool=false`: if the `sink` argument provided is an existing table, `append=true` will append the source's data to the existing data instead of doing a full replace
 * `transforms::Dict{Union{String,Int},Function}`: a Dict of transforms to apply to values as they are parsed. Note that a column can be specified by either number or column name.
 * `transpose::Bool=false`: when reading the underlying csv data, rows should be treated as columns and columns as rows, thus the resulting dataset will be the "transpose" of the actual csv data.
+* `categorical::Bool=true`: read string columns as CategoricalArrays, as long as the % of unique values seen during type detection isn't 100%
 
 Note by default, "string" or text columns will be parsed as the [`WeakRefString`](https://github.com/quinnj/WeakRefStrings.jl) type. This is a custom type that only stores a pointer to the actual byte data + the number of bytes.
 To convert a `String` to a standard Julia string type, just call `string(::WeakRefString)`, this also works on an entire column.

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -14,6 +14,7 @@ function TransposedSource(fullpath::Union{AbstractString,IO};
               decimal=PERIOD,
               truestring="true",
               falsestring="false",
+              categorical::Bool=true,
 
               footerskip::Int=0,
               rows_for_type_detect::Int=20,
@@ -28,7 +29,7 @@ function TransposedSource(fullpath::Union{AbstractString,IO};
                                             quotechar=typeof(quotechar) <: String ? UInt8(first(quotechar)) : (quotechar % UInt8),
                                             escapechar=typeof(escapechar) <: String ? UInt8(first(escapechar)) : (escapechar % UInt8),
                                             null=null, dateformat=dateformat, decimal=decimal, truestring=truestring, falsestring=falsestring),
-                        header=header, datarow=datarow, types=types, nullable=nullable, footerskip=footerskip,
+                        header=header, datarow=datarow, types=types, nullable=nullable, categorical=categorical, footerskip=footerskip,
                         rows_for_type_detect=rows_for_type_detect, rows=rows, use_mmap=use_mmap)
 end
 
@@ -39,6 +40,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
                 datarow::Int=-1, # by default, data starts immediately after header or start of file
                 types=Type[],
                 nullable::Union{Bool, Null}=null,
+                categorical::Bool=true,
 
                 footerskip::Int=0,
                 rows_for_type_detect::Int=20,
@@ -184,6 +186,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
         columntypes = types
     elseif isa(types, Dict) || isempty(types)
         columntypes = Vector{Type}(cols)
+        levels = Dict{Int, Set{WeakRefString{UInt8}}}(i=>Set{WeakRefString{UInt8}}() for i = 1:cols)
         fill!(columntypes, Any)
         lineschecked = 0
         while !eof(source) && lineschecked < min(rows < 0 ? rows_for_type_detect : rows, rows_for_type_detect)
@@ -192,7 +195,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
             for i = 1:cols
                 # print("\tdetecting col = $i...")
                 seek(source, columnpositions[i])
-                typ = CSV.detecttype(source, options, columntypes[i])::Type
+                typ = CSV.detecttype(source, options, columntypes[i], levels[i])::Type
                 columnpositions[i] = position(source)
                 # print(typ)
                 columntypes[i] = CSV.promote_type2(columntypes[i], typ)
@@ -204,6 +207,13 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
             options = Options(delim=options.delim, quotechar=options.quotechar, escapechar=options.escapechar,
                               null=options.null, dateformat=Dates.ISODateTimeFormat, decimal=options.decimal,
                               datarow=options.datarow, rows=options.rows, header=options.header, types=options.types)
+        end
+        if categorical
+            for i = 1:cols
+                T = columntypes[i]
+                columntypes[i] = ifelse(length(levels[i]) / rows_for_type_detect < .67 && T <: WeakRefString,
+                    CategoricalValue{String, UInt32}, T)
+            end
         end
     else
         throw(ArgumentError("$cols number of columns detected; `types` argument has $(length(types)) entries"))

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -95,7 +95,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
         columnpositions = [position(source)]
         datapos = position(source)
         rows = 0
-        b = peekbyte(source)
+        b = eof(source) ? 0x00 : peekbyte(source)
         while !eof(source) && b != NEWLINE && b != RETURN
             b = readbyte(source)
             rows += ifelse(b == options.delim, 1, 0)
@@ -118,7 +118,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
             cols += 1
             push!(columnnames, strip(parsefield(source, String, options, cols, row)))
             push!(columnpositions, position(source))
-            b = peekbyte(source)
+            b = eof(source) ? 0x00 : peekbyte(source)
             while !eof(source) && b != NEWLINE && b != RETURN
                 b = readbyte(source)
             end

--- a/src/io.jl
+++ b/src/io.jl
@@ -215,7 +215,7 @@ promote_type2(::Type{Null}, ::Type{WeakRefString{UInt8}}) = Union{WeakRefString{
 promote_type2(::Type{Any}, ::Type{Null}) = Null
 promote_type2(::Type{Null}, ::Type{Null}) = Null
 
-function detecttype(io, opt::CSV.Options{D}, prevT, seen) where {D}
+function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
     pos = position(io)
     if Int <: prevT || prevT == Null
         try
@@ -267,7 +267,7 @@ function detecttype(io, opt::CSV.Options{D}, prevT, seen) where {D}
     try
         seek(io, pos)
         v7 = CSV.parsefield(io, Union{WeakRefString{UInt8}, Null}, opt)
-        push!(seen, v7)
+        push!(levels, v7)
         # print("...parsed = '$v1'...")
         return v7 isa Null ? Null : WeakRefString{UInt8}
     end

--- a/src/io.jl
+++ b/src/io.jl
@@ -215,7 +215,7 @@ promote_type2(::Type{Null}, ::Type{WeakRefString{UInt8}}) = Union{WeakRefString{
 promote_type2(::Type{Any}, ::Type{Null}) = Null
 promote_type2(::Type{Null}, ::Type{Null}) = Null
 
-function detecttype(io, opt::CSV.Options{D}, prevT) where {D}
+function detecttype(io, opt::CSV.Options{D}, prevT, seen) where {D}
     pos = position(io)
     if Int <: prevT || prevT == Null
         try
@@ -267,6 +267,7 @@ function detecttype(io, opt::CSV.Options{D}, prevT) where {D}
     try
         seek(io, pos)
         v7 = CSV.parsefield(io, Union{WeakRefString{UInt8}, Null}, opt)
+        push!(seen, v7)
         # print("...parsed = '$v1'...")
         return v7 isa Null ? Null : WeakRefString{UInt8}
     end

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -311,6 +311,11 @@ end
     throw(ParsingException(Bool, b, row, col))
 end
 
+@inline function parsefield(io::IO, ::Type{<:CategoricalValue}, opt::CSV.Options, row, col, state, ifnull::Function)
+    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifnull)
+    return v isa Null ? ifnull(row, col) : v
+end
+
 # Generic fallback
 @inline function parsefield(io::IO, T, opt::CSV.Options, row, col, state, ifnull::Function)
     v = parsefield(io, String, opt, row, col, state, ifnull)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using CSV
-using Base.Test, DataStreams, Nulls, WeakRefStrings
+using Base.Test, DataStreams, Nulls, WeakRefStrings, CategoricalArrays
 
 include("parsefields.jl")
 include("io.jl")

--- a/test/source.jl
+++ b/test/source.jl
@@ -201,7 +201,7 @@ f = CSV.Source(joinpath(dir, "SacramentocrimeJanuary2006.csv"))
 @test size(Data.schema(f), 2) == 9
 @test size(Data.schema(f), 1) == 7584
 @test Data.header(Data.schema(f)) == ["cdatetime","address","district","beat","grid","crimedescr","ucr_ncic_code","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},Int,CategoricalValue{String,UInt32},Int,Float64,Float64)
+@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},Int,WeakRefString{UInt8},Int,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Sacramentorealestatetransactions.csv"))
@@ -236,14 +236,14 @@ f = CSV.Source(joinpath(dir, "Fielding.csv"); nullable=true, types=Dict("GS"=>In
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 167938
 @test Data.header(Data.schema(f)) == ["playerID","yearID","stint","teamID","lgID","POS","G","GS","InnOuts","PO","A","E","DP","PB","WP","SB","CS","ZR"]
-@test Data.types(Data.schema(f)) == (Union{WeakRefString{UInt8}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null})
+@test Data.types(Data.schema(f)) == (Union{CategoricalValue{String,UInt32}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "latest (1).csv"); header=0, null="\\N", types=Dict(13=>Union{Float64, Null},17=>Union{Int, Null},18=>Union{Float64, Null},20=>Union{Float64, Null}))
 @test size(Data.schema(f), 2) == 25
 @test size(Data.schema(f), 1) == 1000
 @test Data.header(Data.schema(f)) == ["Column$i" for i = 1:size(Data.schema(f), 2)]
-@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32}, CategoricalValue{String,UInt32}, Int64, Int64, CategoricalValue{String,UInt32}, Int64, CategoricalValue{String,UInt32}, Int64, Date, Date, Int64, WeakRefString{UInt8}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Union{Float64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null})
+@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32}, CategoricalValue{String,UInt32}, Int64, Int64, CategoricalValue{String,UInt32}, Int64, CategoricalValue{String,UInt32}, Int64, Date, Date, Int64, CategoricalValue{String,UInt32}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Union{Float64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "pandas_zeros.csv"))

--- a/test/source.jl
+++ b/test/source.jl
@@ -78,14 +78,14 @@ f = CSV.Source(joinpath(dir, "test_simple_quoted.csv"))
 @test size(Data.schema(f), 2) == 2
 @test size(Data.schema(f), 1) == 1
 ds = CSV.read(f)
-@test string(ds[1][1]) == "quoted field 1"
-@test string(ds[2][1]) == "quoted field 2"
+@test String(ds[1][1]) == "quoted field 1"
+@test String(ds[2][1]) == "quoted field 2"
 f = CSV.Source(joinpath(dir, "test_quoted_delim_and_newline.csv"))
 @test size(Data.schema(f), 2) == 2
 @test size(Data.schema(f), 1) == 1
 
 @testset "quoted numbers detected as string column" begin
-    f = CSV.Source(joinpath(dir, "test_quoted_numbers.csv"))
+    f = CSV.Source(joinpath(dir, "test_quoted_numbers.csv"); categorical=false)
     @test size(Data.schema(f), 2) == 3
     @test size(Data.schema(f), 1) == 3
     ds = CSV.read(f)
@@ -151,7 +151,7 @@ f = CSV.Source(joinpath(dir, "test_float_in_int_column.csv"); types=[Int,Int,Int
 @test_throws CSV.ParsingException CSV.read(f)
 
 #test null/missing values
-f = CSV.Source(joinpath(dir, "test_missing_value_NULL.csv"))
+f = CSV.Source(joinpath(dir, "test_missing_value_NULL.csv"); categorical=false)
 @test size(Data.schema(f), 2) == 3
 @test size(Data.schema(f), 1) == 3
 @test Data.types(Data.schema(f)) == (Float64,WeakRefString{UInt8},Float64)
@@ -187,35 +187,35 @@ f = CSV.Source(joinpath(dir, "FL_insurance_sample.csv"); types=Dict(10=>Float64,
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 36634
 @test Data.header(Data.schema(f)) == ["policyID","statecode","county","eq_site_limit","hu_site_limit","fl_site_limit","fr_site_limit","tiv_2011","tiv_2012","eq_site_deductible","hu_site_deductible","fl_site_deductible","fr_site_deductible","point_latitude","point_longitude","line","construction","point_granularity"]
-@test Data.types(Data.schema(f)) == (Int,WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,WeakRefString{UInt8},WeakRefString{UInt8},Int)
+@test Data.types(Data.schema(f)) == (Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "FL_insurance_sample.csv");types=Dict("eq_site_deductible"=>Float64,"fl_site_deductible"=>Float64))
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 36634
 @test Data.header(Data.schema(f)) == ["policyID","statecode","county","eq_site_limit","hu_site_limit","fl_site_limit","fr_site_limit","tiv_2011","tiv_2012","eq_site_deductible","hu_site_deductible","fl_site_deductible","fr_site_deductible","point_latitude","point_longitude","line","construction","point_granularity"]
-@test Data.types(Data.schema(f)) == (Int,WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,WeakRefString{UInt8},WeakRefString{UInt8},Int)
+@test Data.types(Data.schema(f)) == (Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "SacramentocrimeJanuary2006.csv"))
 @test size(Data.schema(f), 2) == 9
 @test size(Data.schema(f), 1) == 7584
 @test Data.header(Data.schema(f)) == ["cdatetime","address","district","beat","grid","crimedescr","ucr_ncic_code","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},WeakRefString{UInt8},Int,WeakRefString{UInt8},Int,WeakRefString{UInt8},Int,Float64,Float64)
+@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},Int,CategoricalValue{String,UInt32},Int,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Sacramentorealestatetransactions.csv"))
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 985
 @test Data.header(Data.schema(f)) == ["street","city","zip","state","beds","baths","sq__ft","type","sale_date","price","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},WeakRefString{UInt8},Int,WeakRefString{UInt8},Int,Int,Int,WeakRefString{UInt8},WeakRefString{UInt8},Int,Float64,Float64)
+@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalValue{String,UInt32},Int,CategoricalValue{String,UInt32},Int,Int,Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "SalesJan2009.csv"); types=Dict(3=>WeakRefString{UInt8},7=>Union{WeakRefString{UInt8}, Null}))
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 998
 @test Data.header(Data.schema(f)) == ["Transaction_date","Product","Price","Payment_Type","Name","City","State","Country","Account_Created","Last_Login","Latitude","Longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},WeakRefString{UInt8},WeakRefString{UInt8},WeakRefString{UInt8},WeakRefString{UInt8},WeakRefString{UInt8},Union{WeakRefString{UInt8}, Null},WeakRefString{UInt8},WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64)
+@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalValue{String,UInt32},WeakRefString{UInt8},CategoricalValue{String,UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Union{WeakRefString{UInt8}, Null},CategoricalValue{String,UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "stocks.csv"))
@@ -229,21 +229,21 @@ f = CSV.Source(joinpath(dir, "TechCrunchcontinentalUSA.csv"); types=Dict(4=>Unio
 @test size(Data.schema(f), 2) == 10
 @test size(Data.schema(f), 1) == 1460
 @test Data.header(Data.schema(f)) == ["permalink","company","numEmps","category","city","state","fundedDate","raisedAmt","raisedCurrency","round"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},WeakRefString{UInt8},Union{Int, Null},Union{WeakRefString{UInt8}, Null},Union{WeakRefString{UInt8}, Null},WeakRefString{UInt8},WeakRefString{UInt8},Int,WeakRefString{UInt8},WeakRefString{UInt8})
+@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Union{Int, Null},Union{WeakRefString{UInt8}, Null},Union{WeakRefString{UInt8}, Null},CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Fielding.csv"); nullable=true, types=Dict("GS"=>Int,"InnOuts"=>Int,"WP"=>Int,"SB"=>Int,"CS"=>Int,"ZR"=>Int))
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 167938
 @test Data.header(Data.schema(f)) == ["playerID","yearID","stint","teamID","lgID","POS","G","GS","InnOuts","PO","A","E","DP","PB","WP","SB","CS","ZR"]
-@test Data.types(Data.schema(f)) == (Union{WeakRefString{UInt8}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{WeakRefString{UInt8}, Null}, Union{WeakRefString{UInt8}, Null}, Union{WeakRefString{UInt8}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null})
+@test Data.types(Data.schema(f)) == (Union{WeakRefString{UInt8}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{CategoricalValue{String,UInt32}, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null}, Union{Int64, Null})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "latest (1).csv"); header=0, null="\\N", types=Dict(13=>Union{Float64, Null},17=>Union{Int, Null},18=>Union{Float64, Null},20=>Union{Float64, Null}))
 @test size(Data.schema(f), 2) == 25
 @test size(Data.schema(f), 1) == 1000
 @test Data.header(Data.schema(f)) == ["Column$i" for i = 1:size(Data.schema(f), 2)]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8}, WeakRefString{UInt8}, Int64, Int64, WeakRefString{UInt8}, Int64, WeakRefString{UInt8}, Int64, Date, Date, Int64, WeakRefString{UInt8}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Union{Float64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null})
+@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32}, CategoricalValue{String,UInt32}, Int64, Int64, CategoricalValue{String,UInt32}, Int64, CategoricalValue{String,UInt32}, Int64, Date, Date, Int64, WeakRefString{UInt8}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Union{Float64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null}, Union{Int64, Null}, Float64, Union{Float64, Null}, Union{Float64, Null})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "pandas_zeros.csv"))


### PR DESCRIPTION
cc @nalimilan 

This ended up being more minimal than I expected. I know we're cheating a bit by just returning a WeakRefString from the `CSV.parsefield(io, ::Type{CategoricalValue})` function, but in the DataStreams system, I think this should be fine. The important part is the Source's Data.schema have `CategoricalValue` in the types and that the Sink be able to handle them. I still need to do some more Sink testing, but so far, they're already setup to handle this just fine.

Fixes #43.