### PR TITLE
Type detection fixes

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -175,15 +175,15 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         end
     end
     if !ismissing(nullable)
-        if nullable
+        if nullable # allow missing values in all columns
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(T >: Missing, T, Union{T, Missing})
+                columntypes[i] = Union{Missings.T(T), Missing}
             end
-        else
+        else # disallow missing values in all columns
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(T >: Missing, Missings.T(T), T)
+                columntypes[i] = Missings.T(T)
             end
         end
     end

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -157,8 +157,13 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         if categorical
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(length(levels[i]) / rows_for_type_detect < .67 && T <: WeakRefString,
-                    CategoricalValue{String, UInt32}, T)
+                if length(levels[i]) / rows_for_type_detect < .67 &&
+                        T !== Missing && Missings.T(T) <: WeakRefString
+                    columntypes[i] = CategoricalArrays.catvaluetype(Missings.T(T), UInt32)
+                    if T >: Missing
+                        columntypes[i] = Union{columntypes[i], Missing}
+                    end
+                end
             end
         end
     else

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -133,9 +133,8 @@ function Source(;fullpath::Union{AbstractString,IO}="",
     if isa(types, Vector) && length(types) == cols
         columntypes = types
     elseif isa(types, Dict) || isempty(types)
-        columntypes = Vector{Type}(cols)
-        levels = Dict{Int, Set{WeakRefString{UInt8}}}(i=>Set{WeakRefString{UInt8}}() for i = 1:cols)
-        fill!(columntypes, Any)
+        columntypes = fill!(Vector{Type}(cols), Any)
+        levels = [Dict{WeakRefString{UInt8}, Int}() for _ = 1:cols]
         lineschecked = 0
         while !eof(source) && lineschecked < min(rows < 0 ? rows_for_type_detect : rows, rows_for_type_detect)
             lineschecked += 1
@@ -157,7 +156,7 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         if categorical
             for i = 1:cols
                 T = columntypes[i]
-                if length(levels[i]) / rows_for_type_detect < .67 &&
+                if length(levels[i]) / sum(values(levels[i])) < .67 &&
                         T !== Missing && Missings.T(T) <: WeakRefString
                     columntypes[i] = CategoricalArrays.catvaluetype(Missings.T(T), UInt32)
                     if T >: Missing

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -239,7 +239,7 @@ Keyword Arguments:
 * `types`: column types can be provided manually as a complete Vector{Type}, or in a Dict to reference individual columns by name or number
 * `nullable::Bool`: indicates whether values can be nullable or not; `true` by default. If set to `false` and missing values are encountered, a `Data.NullException` will be thrown
 * `footerskip::Int`: indicates the number of rows to skip at the end of the file
-* `rows_for_type_detect::Int=100`: indicates how many rows should be read to infer the types of columns
+* `rows_for_type_detect::Int=20`: indicates how many rows should be read to infer the types of columns
 * `rows::Int`: indicates the total number of rows to read from the file; by default the file is pre-parsed to count the # of rows; `-1` can be passed to skip a full-file scan, but the `Data.Sink` must be setup account for a potentially unknown # of rows
 * `use_mmap::Bool=true`: whether the underlying file will be mmapped or not while parsing; note that on Windows machines, the underlying file will not be "deletable" until Julia GC has run (can be run manually via `gc()`) due to the use of a finalizer when reading the file.
 * `append::Bool=false`: if the `sink` argument provided is an existing table, `append=true` will append the source's data to the existing data instead of doing a full replace

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -230,15 +230,15 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
         end
     end
     if !ismissing(nullable)
-        if nullable
+        if nullable # allow missing values in all columns
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(T >: Missing, T, Union{T, Missing})
+                columntypes[i] = Union{Missings.T(T), Missing}
             end
-        else
+        else # disallow missing values in all columns
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(T >: Missing, Missings.T(T), T)
+                columntypes[i] = Missings.T(T)
             end
         end
     end

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -185,9 +185,8 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
     if isa(types, Vector) && length(types) == cols
         columntypes = types
     elseif isa(types, Dict) || isempty(types)
-        columntypes = Vector{Type}(cols)
-        levels = Dict{Int, Set{WeakRefString{UInt8}}}(i=>Set{WeakRefString{UInt8}}() for i = 1:cols)
-        fill!(columntypes, Any)
+        columntypes = fill!(Vector{Type}(cols), Any)
+        levels = [Dict{WeakRefString{UInt8}, Int}() for _ = 1:cols]
         lineschecked = 0
         while !eof(source) && lineschecked < min(rows < 0 ? rows_for_type_detect : rows, rows_for_type_detect)
             lineschecked += 1
@@ -211,7 +210,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
         if categorical
             for i = 1:cols
                 T = columntypes[i]
-                if length(levels[i]) / rows_for_type_detect < .67 &&
+                if length(levels[i]) / sum(values(levels[i])) < .67 &&
                         T !== Missing && Missings.T(T) <: WeakRefString
                     columntypes[i] = CategoricalArrays.catvaluetype(Missings.T(T), UInt32)
                     if T >: Missing

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -211,8 +211,13 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
         if categorical
             for i = 1:cols
                 T = columntypes[i]
-                columntypes[i] = ifelse(length(levels[i]) / rows_for_type_detect < .67 && T <: WeakRefString,
-                    CategoricalValue{String, UInt32}, T)
+                if length(levels[i]) / rows_for_type_detect < .67 &&
+                        T !== Missing && Missings.T(T) <: WeakRefString
+                    columntypes[i] = CategoricalArrays.catvaluetype(Missings.T(T), UInt32)
+                    if T >: Missing
+                        columntypes[i] = Union{columntypes[i], Missing}
+                    end
+                end
             end
         end
     else

--- a/src/io.jl
+++ b/src/io.jl
@@ -217,8 +217,14 @@ promote_type2(::Type{Missing}, ::Type{Missing}) = Missing
 
 function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
     pos = position(io)
+    # update levels
+    try
+        lev = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing}, opt)
+        ismissing(lev) || (levels[lev] = get!(levels, lev, 0) + 1)
+    end
     if Int <: prevT || prevT == Missing
         try
+            seek(io, pos)
             v1 = CSV.parsefield(io, Union{Int, Missing}, opt)
             # print("...parsed = '$v1'...")
             return v1 isa Missing ? Missing : Int
@@ -267,8 +273,7 @@ function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
     try
         seek(io, pos)
         v7 = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing}, opt)
-        push!(levels, v7)
-        # print("...parsed = '$v1'...")
+        # print("...parsed = '$v7'...")
         return v7 isa Missing ? Missing : WeakRefString{UInt8}
     end
     return Missing

--- a/src/io.jl
+++ b/src/io.jl
@@ -204,8 +204,10 @@ promote_type2(::Type{DateTime}, ::Type{Date}) = DateTime
 # for cases when our current type can't widen, just promote to WeakRefString
 promote_type2(::Type{<:Real}, ::Type{<:Dates.TimeType}) = WeakRefString{UInt8}
 promote_type2(::Type{<:Dates.TimeType}, ::Type{<:Real}) = WeakRefString{UInt8}
-promote_type2(::Type{<:Any}, ::Type{WeakRefString{UInt8}}) = WeakRefString{UInt8}
-promote_type2(::Type{WeakRefString{UInt8}}, ::Type{<:Any}) = WeakRefString{UInt8}
+promote_type2(::Type{T}, ::Type{WeakRefString{UInt8}}) where T = WeakRefString{UInt8}
+promote_type2(::Type{Union{T, Missing}}, ::Type{WeakRefString{UInt8}}) where T = Union{WeakRefString{UInt8}, Missing}
+promote_type2(::Type{WeakRefString{UInt8}}, ::Type{T}) where T = WeakRefString{UInt8}
+promote_type2(::Type{WeakRefString{UInt8}}, ::Type{Union{T, Missing}}) where T = Union{WeakRefString{UInt8}, Missing}
 # avoid ambiguity
 promote_type2(::Type{Any}, ::Type{WeakRefString{UInt8}}) = WeakRefString{UInt8}
 promote_type2(::Type{WeakRefString{UInt8}}, ::Type{Any}) = WeakRefString{UInt8}

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -311,7 +311,7 @@ end
     throw(ParsingException(Bool, b, row, col))
 end
 
-@inline function parsefield(io::IO, ::Type{<:CategoricalValue}, opt::CSV.Options, row, col, state, ifnull::Function)
+@inline function parsefield(io::IO, ::Type{<:Union{CategoricalValue, CategoricalString}}, opt::CSV.Options, row, col, state, ifnull::Function)
     v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifnull)
     return v isa Missing ? ifnull(row, col) : v
 end

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -135,13 +135,13 @@ parsefield(source::CSV.Source, ::Type{Missing}, row=0, col=0, state::P=P()) = CS
     v = zero(T)
     negative = false
     if b == MINUS # check for leading '-' or '+'
-        c = peekbyte(io) 
+        c = peekbyte(io)
         if NEG_ONE < c < TEN
             negative = true
             b = readbyte(io)
         end
     elseif b == PLUS
-        c = peekbyte(io) 
+        c = peekbyte(io)
         if NEG_ONE < c < TEN
             b = readbyte(io)
         end
@@ -300,7 +300,7 @@ end
         @checkdone(done)
     end
     @checknullend()
-    
+
     @label done
     return v
 

--- a/test/source.jl
+++ b/test/source.jl
@@ -178,7 +178,7 @@ f = CSV.Source(joinpath(dir, "baseball.csv"); rows_for_type_detect=35)
 @test size(Data.schema(f), 2) == 15
 @test size(Data.schema(f), 1) == 35
 @test Data.header(Data.schema(f)) == ["Rk","Year","Age","Tm","Lg","","W","L","W-L%","G","Finish","Wpost","Lpost","W-L%post",""]
-@test Data.types(Data.schema(f)) == (Union{Int, Missing},Union{Int, Missing},Union{Int, Missing},Union{WeakRefString{UInt8}, Missing},Union{WeakRefString{UInt8}, Missing},Union{WeakRefString{UInt8}, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{WeakRefString{UInt8}, Missing})
+@test Data.types(Data.schema(f)) == (Union{Int, Missing},Union{Int, Missing},Union{Int, Missing},Union{CategoricalString{UInt32}, Missing},Union{CategoricalString{UInt32}, Missing},Union{WeakRefString{UInt8}, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{CategoricalString{UInt32}, Missing})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "FL_insurance_sample.csv"); types=Dict(10=>Float64,12=>Float64))

--- a/test/source.jl
+++ b/test/source.jl
@@ -185,35 +185,35 @@ f = CSV.Source(joinpath(dir, "FL_insurance_sample.csv"); types=Dict(10=>Float64,
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 36634
 @test Data.header(Data.schema(f)) == ["policyID","statecode","county","eq_site_limit","hu_site_limit","fl_site_limit","fr_site_limit","tiv_2011","tiv_2012","eq_site_deductible","hu_site_deductible","fl_site_deductible","fr_site_deductible","point_latitude","point_longitude","line","construction","point_granularity"]
-@test Data.types(Data.schema(f)) == (Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int)
+@test Data.types(Data.schema(f)) == (Int,CategoricalString{UInt32},CategoricalString{UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalString{UInt32},CategoricalString{UInt32},Int)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "FL_insurance_sample.csv");types=Dict("eq_site_deductible"=>Float64,"fl_site_deductible"=>Float64))
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 36634
 @test Data.header(Data.schema(f)) == ["policyID","statecode","county","eq_site_limit","hu_site_limit","fl_site_limit","fr_site_limit","tiv_2011","tiv_2012","eq_site_deductible","hu_site_deductible","fl_site_deductible","fr_site_deductible","point_latitude","point_longitude","line","construction","point_granularity"]
-@test Data.types(Data.schema(f)) == (Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int)
+@test Data.types(Data.schema(f)) == (Int,CategoricalString{UInt32},CategoricalString{UInt32},Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Float64,Int,Float64,Float64,CategoricalString{UInt32},CategoricalString{UInt32},Int)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "SacramentocrimeJanuary2006.csv"))
 @test size(Data.schema(f), 2) == 9
 @test size(Data.schema(f), 1) == 7584
 @test Data.header(Data.schema(f)) == ["cdatetime","address","district","beat","grid","crimedescr","ucr_ncic_code","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},Int,WeakRefString{UInt8},Int,Float64,Float64)
+@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},WeakRefString{UInt8},Int,CategoricalString{UInt32},Int,WeakRefString{UInt8},Int,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Sacramentorealestatetransactions.csv"))
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 985
 @test Data.header(Data.schema(f)) == ["street","city","zip","state","beds","baths","sq__ft","type","sale_date","price","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalValue{String,UInt32},Int,CategoricalValue{String,UInt32},Int,Int,Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Int,Float64,Float64)
+@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalString{UInt32},Int,CategoricalString{UInt32},Int,Int,Int,CategoricalString{UInt32},CategoricalString{UInt32},Int,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "SalesJan2009.csv"); types=Dict(3=>WeakRefString{UInt8},7=>Union{WeakRefString{UInt8}, Missing}))
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 998
 @test Data.header(Data.schema(f)) == ["Transaction_date","Product","Price","Payment_Type","Name","City","State","Country","Account_Created","Last_Login","Latitude","Longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalValue{String,UInt32},WeakRefString{UInt8},CategoricalValue{String,UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Union{WeakRefString{UInt8}, Missing},CategoricalValue{String,UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64)
+@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalString{UInt32},WeakRefString{UInt8},CategoricalString{UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Union{WeakRefString{UInt8}, Missing},CategoricalString{UInt32},WeakRefString{UInt8},WeakRefString{UInt8},Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "stocks.csv"))
@@ -227,21 +227,21 @@ f = CSV.Source(joinpath(dir, "TechCrunchcontinentalUSA.csv"); types=Dict(4=>Unio
 @test size(Data.schema(f), 2) == 10
 @test size(Data.schema(f), 1) == 1460
 @test Data.header(Data.schema(f)) == ["permalink","company","numEmps","category","city","state","fundedDate","raisedAmt","raisedCurrency","round"]
-@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32},CategoricalValue{String,UInt32},Union{Int, Missing},Union{WeakRefString{UInt8}, Missing},Union{WeakRefString{UInt8}, Missing},CategoricalValue{String,UInt32},WeakRefString{UInt8},Int,CategoricalValue{String,UInt32},CategoricalValue{String,UInt32})
+@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},CategoricalString{UInt32},Union{Int, Missing},Union{WeakRefString{UInt8}, Missing},Union{WeakRefString{UInt8}, Missing},CategoricalString{UInt32},WeakRefString{UInt8},Int,CategoricalString{UInt32},CategoricalString{UInt32})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Fielding.csv"); nullable=true, types=Dict("GS"=>Int,"InnOuts"=>Int,"WP"=>Int,"SB"=>Int,"CS"=>Int,"ZR"=>Int))
 @test size(Data.schema(f), 2) == 18
 @test size(Data.schema(f), 1) == 167938
 @test Data.header(Data.schema(f)) == ["playerID","yearID","stint","teamID","lgID","POS","G","GS","InnOuts","PO","A","E","DP","PB","WP","SB","CS","ZR"]
-@test Data.types(Data.schema(f)) == (Union{CategoricalValue{String,UInt32}, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{CategoricalValue{String,UInt32}, Missing}, Union{CategoricalValue{String,UInt32}, Missing}, Union{CategoricalValue{String,UInt32}, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing})
+@test Data.types(Data.schema(f)) == (Union{CategoricalString{UInt32}, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{CategoricalString{UInt32}, Missing}, Union{CategoricalString{UInt32}, Missing}, Union{CategoricalString{UInt32}, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing}, Union{Int64, Missing})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "latest (1).csv"); header=0, null="\\N", types=Dict(13=>Union{Float64, Missing},17=>Union{Int, Missing},18=>Union{Float64, Missing},20=>Union{Float64, Missing}))
 @test size(Data.schema(f), 2) == 25
 @test size(Data.schema(f), 1) == 1000
 @test Data.header(Data.schema(f)) == ["Column$i" for i = 1:size(Data.schema(f), 2)]
-@test Data.types(Data.schema(f)) == (CategoricalValue{String,UInt32}, CategoricalValue{String,UInt32}, Int64, Int64, CategoricalValue{String,UInt32}, Int64, CategoricalValue{String,UInt32}, Int64, Date, Date, Int64, CategoricalValue{String,UInt32}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Int64, Missing}, Union{Float64, Missing}, Float64, Union{Float64, Missing}, Union{Float64, Missing}, Union{Int64, Missing}, Float64, Union{Float64, Missing}, Union{Float64, Missing})
+@test Data.types(Data.schema(f)) == (CategoricalString{UInt32}, CategoricalString{UInt32}, Int64, Int64, CategoricalString{UInt32}, Int64, CategoricalString{UInt32}, Int64, Date, Date, Int64, CategoricalString{UInt32}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Int64, Missing}, Union{Float64, Missing}, Float64, Union{Float64, Missing}, Union{Float64, Missing}, Union{Int64, Missing}, Float64, Union{Float64, Missing}, Union{Float64, Missing})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "pandas_zeros.csv"))

--- a/test/source.jl
+++ b/test/source.jl
@@ -439,3 +439,8 @@ ds = CSV.read(f)
 # #107
 df = CSV.read(IOBuffer("1,a,i\n2,b,ii\n3,c,iii"); datarow=1)
 @test size(df) == (3, 3)
+
+# #115 (Int -> Union{Int, Missing} -> Union{WeakRefString, Missing} promotion)
+df = CSV.read(joinpath(dir, "attenu.csv"), null="NA", rows_for_type_detect=200)
+@test size(df) == (182, 5)
+@test Data.types(Data.schema(df)) == (Int, Float64, Union{Missings.Missing, WeakRefString{UInt8}}, Float64, Float64)


### PR DESCRIPTION
Fixes a few issues with type detection
* use `CategoricalArrays.catvaluetype()` to return the value of categorical (should be `CategoricalString` for `WeakRefString`, previously was `CategoricalValue`)
* start counting column levels from the very beginning, otherwise when the column is detected to be `WeakRefString` many levels are skipped
* allow categorical type for the columns with missing values
* ignore rows with missing values when calculating the fraction of unique values (for that `levels::Set{Str}` changed into `levels::Dict{Str, Int}` (the last 3 bullet points tested in `baseball.csv`)
* fix `promote_rule2(Union{T, Missing}, WeakRefString)`, should be `Union{WeakRefString, Missing}` (was `WeakRefString`) -- that's where `attenu.csv` of RDatasets was failing