### PR TITLE
Deploy docs from Julia 0.6

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,6 @@ deploydocs(
     target = "build",
     deps = nothing,
     make = nothing,
-    julia = "0.5",
+    julia = "0.6",
     osname = "linux"
 )


### PR DESCRIPTION
This explains why online manual was out of date.