### PR TITLE
Replace all uses of null with missing

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -77,14 +77,14 @@ using CSV, TextParse
 for T in (Int, Float64, WeakRefStrings.WeakRefString{UInt8}, Date, DateTime)
     println("comparing for T = $T...")
     # T == WeakRefStrings.WeakRefString{UInt8} && continue
-    @time CSV.read("/Users/jacobquinn/Downloads/randoms_$(T).csv"; nullable=true);
+    @time CSV.read("/Users/jacobquinn/Downloads/randoms_$(T).csv"; allowmissing=true);
     # @time TextParse.csvread("/Users/jacobquinn/Downloads/randoms_$T.csv");
 end
 
 for T in (Int, Float64, WeakRefStrings.WeakRefString{UInt8}, Date, DateTime)
     println("comparing for T = $T...")
     # T == WeakRefStrings.WeakRefString{UInt8} && continue
-    # @time CSV.read("/Users/jacobquinn/Downloads/randoms_$(T).csv"; nullable=true);
+    # @time CSV.read("/Users/jacobquinn/Downloads/randoms_$(T).csv"; allowmissing=true);
     @time TextParse.csvread("/Users/jacobquinn/Downloads/randoms_$T.csv");
 end
 
@@ -135,8 +135,8 @@ print(end - start)
 
 T = Int64
 @time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_$(T).csv";)
-@time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_small.csv"; nullable=true)
-@time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_small.csv"; nullable=false)
+@time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_small.csv"; allowmissing=true)
+@time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_small.csv"; allowmissing=false)
 # source.schema = DataStreams.Data.Schema(DataStreams.Data.header(source.schema), (Int, String, String, Float64, Float64, Date, DateTime), 9)
 # @time df = CSV.read(source, NamedTuple);
 sink = Si = NamedTuple
@@ -171,7 +171,7 @@ end
 
 t = Vector{Int}(1000000)
 
-# having CSV.parsefield(io, T) where T !>: Null decreases allocations by 1.00M
+# having CSV.parsefield(io, T) where T !>: Missing decreases allocations by 1.00M
 # inlining CSV.parsefield also dropped allocations
 # making CSV.Options not have a type parameter also sped things up
 #

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -50,7 +50,7 @@ Keyword Arguments:
  * `delim::Union{Char,UInt8}`: how fields in the file are delimited; default `','`
  * `quotechar::Union{Char,UInt8}`: the character that indicates a quoted field that may contain the `delim` or newlines; default `'"'`
  * `escapechar::Union{Char,UInt8}`: the character that escapes a `quotechar` in a quoted field; default `'\\'`
- * `null::String`: indicates how NULL values are represented in the dataset; default `""`
+ * `missingstring::String`: indicates how missing values are represented in the dataset; default `""`
  * `dateformat::Union{AbstractString,Dates.DateFormat}`: how dates/datetimes are represented in the dataset; default `Base.Dates.ISODateTimeFormat`
  * `decimal::Union{Char,UInt8}`: character to recognize as the decimal point in a float number, e.g. `3.14` or `3,14`; default `'.'`
  * `truestring`: string to represent `true::Bool` values in a csv file; default `"true"`. Note that `truestring` and `falsestring` cannot start with the same character.
@@ -60,8 +60,8 @@ struct Options{D}
     delim::UInt8
     quotechar::UInt8
     escapechar::UInt8
-    null::Vector{UInt8}
-    nullcheck::Bool
+    missingstring::Vector{UInt8}
+    missingcheck::Bool
     dateformat::D
     decimal::UInt8
     truestring::Vector{UInt8}
@@ -73,16 +73,16 @@ struct Options{D}
     types
 end
 
-Options(;delim=COMMA, quotechar=QUOTE, escapechar=ESCAPE, null="", dateformat=missing, decimal=PERIOD, truestring="true", falsestring="false", datarow=-1, rows=0, header=1, types=Type[]) =
+Options(;delim=COMMA, quotechar=QUOTE, escapechar=ESCAPE, missingstring="", dateformat=missing, decimal=PERIOD, truestring="true", falsestring="false", datarow=-1, rows=0, header=1, types=Type[]) =
     Options(delim%UInt8, quotechar%UInt8, escapechar%UInt8,
-            map(UInt8, collect(ascii(String(null)))), null != "", isa(dateformat, AbstractString) ? Dates.DateFormat(dateformat) : dateformat,
+            map(UInt8, collect(ascii(String(missingstring)))), missingstring != "", isa(dateformat, AbstractString) ? Dates.DateFormat(dateformat) : dateformat,
             decimal%UInt8, map(UInt8, collect(truestring)), map(UInt8, collect(falsestring)), datarow, rows, header, types)
 function Base.show(io::IO,op::Options)
     println(io, "    CSV.Options:")
     println(io, "        delim: '", Char(op.delim), "'")
     println(io, "        quotechar: '", Char(op.quotechar), "'")
     print(io, "        escapechar: '"); escape_string(io, string(Char(op.escapechar)), "\\"); println(io, "'")
-    print(io, "        null: \""); escape_string(io, isempty(op.null) ? "" : String(collect(op.null)), "\\"); println(io, "\"")
+    print(io, "        missingstring: \""); escape_string(io, isempty(op.missingstring) ? "" : String(collect(op.missingstring)), "\\"); println(io, "\"")
     println(io, "        dateformat: ", op.dateformat)
     println(io, "        decimal: '", Char(op.decimal), "'")
     println(io, "        truestring: '$(String(op.truestring))'")

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -2,27 +2,27 @@
 const P = Ref{ParsingState}
 
 # at start of field: check if eof, remove leading whitespace, check if empty field
-# returns `true` if result of initial parsing is a null field
+# returns `true` if result of initial parsing is a missing field
 # also return `b` which is last byte read
-macro checknullstart()
+macro checkmissingstart()
     return esc(quote
         state[] = None
-        eof(io) && (state[] = EOF; @goto null)
+        eof(io) && (state[] = EOF; @goto missing)
         b = readbyte(io)
         while b != opt.delim && (b == CSV.SPACE || b == CSV.TAB || b == opt.quotechar)
-            eof(io) && (state[] = EOF; @goto null)
+            eof(io) && (state[] = EOF; @goto missing)
             b = readbyte(io)
         end
         if b == opt.delim
             state[] = Delimiter
-            @goto null
+            @goto missing
         elseif b == NEWLINE
             state[] = Newline
-            @goto null
+            @goto missing
         elseif b == RETURN
             state[] = Newline
             !eof(io) && peekbyte(io) == NEWLINE && readbyte(io)
-            @goto null
+            @goto missing
         end
     end)
 end
@@ -71,37 +71,37 @@ end
 ParsingException(::Type{T}, b, row, col) where {T} = CSV.ParsingException("error parsing a `$T` value on column $col, row $row; encountered '$(Char(b))'")
 
 # as a last ditch effort, after we've trying parsing the correct type,
-# we check if the field is equal to a custom null type
+# we check if the field is equal to a custom missing type
 # otherwise we give up and throw an error
-macro checknullend()
+macro checkmissingend()
     return esc(quote
-        !opt.nullcheck && @goto error
+        !opt.missingcheck && @goto error
         i = 1
         while true
-            b == opt.null[i] || @goto error
-            (i == length(opt.null) || eof(io)) && break
+            b == opt.missingstring[i] || @goto error
+            (i == length(opt.missingstring) || eof(io)) && break
             b = readbyte(io)
             i += 1
         end
         if !eof(io)
             b = readbyte(io)
-            @checkdone(null)
+            @checkdone(missing)
         end
         state[] = EOF
-        @goto null
+        @goto missing
     end)
 end
 """
-`CSV.parsefield{T}(io::IO, ::Type{T}, opt::CSV.Options=CSV.Options(), row=0, col=0)` => `Nullable{T}`
-`CSV.parsefield{T}(s::CSV.Source, ::Type{T}, row=0, col=0)` => `Nullable{T}``
+`CSV.parsefield{T}(io::IO, ::Type{T}, opt::CSV.Options=CSV.Options(), row=0, col=0)` => `Union{T, Missing}`
+`CSV.parsefield{T}(s::CSV.Source, ::Type{T}, row=0, col=0)` => `Union{T, Missing}``
 
 `io` is an `IO` type that is positioned at the first byte/character of an delimited-file field (i.e. a single cell)
 leading whitespace is ignored for Integer and Float types.
 Specialized methods exist for Integer, Float, String, Date, and DateTime.
 For other types `T`, a generic fallback requires `parse(T, str::String)` to be defined.
-the field value may also be wrapped in `opt.quotechar`; two consecutive `opt.quotechar` results in a null field
-`opt.null` is also checked if there is a custom value provided (i.e. "NA", "\\N", etc.)
-For numeric fields, if field is non-null and non-digit characters are encountered at any point before a delimiter or newline, an error is thrown
+the field value may also be wrapped in `opt.quotechar`; two consecutive `opt.quotechar` results in a missing field
+`opt.missingstring` is also checked if there is a custom value provided (i.e. "NA", "\\N", etc.)
+For numeric fields, if field is non-missing and non-digit characters are encountered at any point before a delimiter or newline, an error is thrown
 
 The second method of `CSV.parsefield` operates on a `CSV.Source` directly allowing for easy usage when writing custom parsing routines.
 Do note, however, that the `row` and `col` arguments are for error-reporting purposes only. A `CSV.Source` maintains internal state with
@@ -119,19 +119,19 @@ end
 """
 function parsefield end
 
-const NULLTHROW = (row, col)->throw(Missings.MissingException("encountered a missing value for a non-null column type on row = $row, col = $col"))
-const NULLRETURN = (row, col)->missing
+const MISSINGTHROW = (row, col)->throw(Missings.MissingException("encountered a missing value for a column type which does not support them on row = $row, col = $col"))
+const MISSINGRETURN = (row, col)->missing
 
-parsefield(source::CSV.Source, ::Type{T}, row=0, col=0, state::P=P()) where {T} = CSV.parsefield(source.io, T, source.options, row, col, state, T !== Missing ? NULLTHROW : NULLRETURN)
-parsefield(source::CSV.Source, ::Type{Union{T, Missing}}, row=0, col=0, state::P=P()) where {T} = CSV.parsefield(source.io, T, source.options, row, col, state, NULLRETURN)
-parsefield(source::CSV.Source, ::Type{Missing}, row=0, col=0, state::P=P()) = CSV.parsefield(source.io, WeakRefString{UInt8}, source.options, row, col, state, NULLRETURN)
+parsefield(source::CSV.Source, ::Type{T}, row=0, col=0, state::P=P()) where {T} = CSV.parsefield(source.io, T, source.options, row, col, state, T !== Missing ? MISSINGTHROW : MISSINGRETURN)
+parsefield(source::CSV.Source, ::Type{Union{T, Missing}}, row=0, col=0, state::P=P()) where {T} = CSV.parsefield(source.io, T, source.options, row, col, state, MISSINGRETURN)
+parsefield(source::CSV.Source, ::Type{Missing}, row=0, col=0, state::P=P()) = CSV.parsefield(source.io, WeakRefString{UInt8}, source.options, row, col, state, MISSINGRETURN)
 
-@inline parsefield(io::IO, ::Type{T}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) where {T} = parsefield(io, T, opt, row, col, state, T !== Missing ? NULLTHROW : NULLRETURN)
-@inline parsefield(io::IO, ::Type{Union{T, Missing}}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) where {T} = parsefield(io, T, opt, row, col, state, NULLRETURN)
-@inline parsefield(io::IO, ::Type{Missing}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, NULLRETURN)
+@inline parsefield(io::IO, ::Type{T}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) where {T} = parsefield(io, T, opt, row, col, state, T !== Missing ? MISSINGTHROW : MISSINGRETURN)
+@inline parsefield(io::IO, ::Type{Union{T, Missing}}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) where {T} = parsefield(io, T, opt, row, col, state, MISSINGRETURN)
+@inline parsefield(io::IO, ::Type{Missing}, opt::CSV.Options=CSV.Options(), row=0, col=0, state::P=P()) = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, MISSINGRETURN)
 
-@inline function parsefield(io::IO, ::Type{T}, opt::CSV.Options, row, col, state, ifnull::Function) where {T <: Integer}
-    @checknullstart()
+@inline function parsefield(io::IO, ::Type{T}, opt::CSV.Options, row, col, state, ifmissing::Function) where {T <: Integer}
+    @checkmissingstart()
     v = zero(T)
     negative = false
     if b == MINUS # check for leading '-' or '+'
@@ -155,13 +155,13 @@ parsefield(source::CSV.Source, ::Type{Missing}, row=0, col=0, state::P=P()) = CS
         b = readbyte(io)
     end
     @checkdone(done)
-    @checknullend()
+    @checkmissingend()
 
     @label done
     return ifelse(negative, -v, v)
 
-    @label null
-    return ifnull(row, col)
+    @label missing
+    return ifmissing(row, col)
 
     @label error
     throw(ParsingException(T, b, row, col))
@@ -179,16 +179,16 @@ make(io::IOBuffer, ::Type{String}, ptr, len) = unsafe_string(ptr, len)
 make(io::IO, ::Type{WeakRefString{UInt8}}, ptr, len) = String(take!(BUF))
 make(io::IO, ::Type{String}, ptr, len) = String(take!(BUF))
 
-@inline function parsefield(io::IO, T::Type{<:AbstractString}, opt::CSV.Options, row, col, state, ifnull::Function)
-    eof(io) && (state[] = EOF; @goto null)
+@inline function parsefield(io::IO, T::Type{<:AbstractString}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    eof(io) && (state[] = EOF; @goto missing)
     ptr = getptr(io)
     len = 0
-    nullcheck = opt.nullcheck # if null is "", then we don't need to byte match it
-    n = opt.null
+    missingcheck = opt.missingcheck # if missingstring is "", then we don't need to byte match it
+    n = opt.missingstring
     q = opt.quotechar
     e = opt.escapechar
     d = opt.delim
-    nulllen = length(n)
+    missinglen = length(n)
     @inbounds while !eof(io)
         b = readbyte(io)
         if b == q
@@ -206,7 +206,7 @@ make(io::IO, ::Type{String}, ptr, len) = String(take!(BUF))
                 elseif b == q
                     break
                 end
-                (nullcheck && len+1 <= nulllen && b == n[len+1]) || (nullcheck = false)
+                (missingcheck && len+1 <= missinglen && b == n[len+1]) || (missingcheck = false)
                 len += incr(io, b)
             end
         elseif b == d
@@ -220,49 +220,49 @@ make(io::IO, ::Type{String}, ptr, len) = String(take!(BUF))
             !eof(io) && peekbyte(io) == NEWLINE && readbyte(io)
             break
         else
-            (nullcheck && len+1 <= nulllen && b == n[len+1]) || (nullcheck = false)
+            (missingcheck && len+1 <= missinglen && b == n[len+1]) || (missingcheck = false)
             len += incr(io, b)
         end
     end
     eof(io) && (state[] = EOF)
-    (len == 0 || nullcheck) && @goto null
+    (len == 0 || missingcheck) && @goto missing
     return make(io, T, ptr, len)
 
-    @label null
+    @label missing
     take!(BUF)
-    return ifnull(row, col)
+    return ifmissing(row, col)
 end
 
-@inline function parsefield(io::IO, ::Type{Date}, opt::CSV.Options, row, col, state, ifnull::Function)
-    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifnull)
-    return v isa Missing ? ifnull(row, col) : Date(v, opt.dateformat)
+@inline function parsefield(io::IO, ::Type{Date}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifmissing)
+    return v isa Missing ? ifmissing(row, col) : Date(v, opt.dateformat)
 end
-@inline function parsefield(io::IO, ::Type{DateTime}, opt::CSV.Options, row, col, state, ifnull::Function)
-    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifnull)
-    return v isa Missing ? ifnull(row, col) : DateTime(v, opt.dateformat)
+@inline function parsefield(io::IO, ::Type{DateTime}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifmissing)
+    return v isa Missing ? ifmissing(row, col) : DateTime(v, opt.dateformat)
 end
 
-@inline function parsefield(io::IO, ::Type{Char}, opt::CSV.Options, row, col, state, ifnull::Function)
-    @checknullstart()
+@inline function parsefield(io::IO, ::Type{Char}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    @checkmissingstart()
     c = b
     eof(io) && (state[] = EOF; @goto done)
-    opt.nullcheck && b == opt.null[1] && @goto null
+    opt.missingcheck && b == opt.missingstring[1] && @goto missing
     b = readbyte(io)
     @checkdone(done)
-    @checknullend()
+    @checkmissingend()
 
     @label done
     return Char(c)
 
-    @label null
-    return ifnull(row, col)
+    @label missing
+    return ifmissing(row, col)
 
     @label error
     throw(ParsingException(Char, b, row, col))
 end
 
-@inline function parsefield(io::IO, ::Type{Bool}, opt::CSV.Options, row, col, state, ifnull::Function)
-    @checknullstart()
+@inline function parsefield(io::IO, ::Type{Bool}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    @checkmissingstart()
     truestring = opt.truestring
     falsestring = opt.falsestring
     i = 1
@@ -299,27 +299,27 @@ end
         end
         @checkdone(done)
     end
-    @checknullend()
-    
+    @checkmissingend()
+
     @label done
     return v
 
-    @label null
-    return ifnull(row, col)
+    @label missing
+    return ifmissing(row, col)
 
     @label error
     throw(ParsingException(Bool, b, row, col))
 end
 
-@inline function parsefield(io::IO, ::Type{<:CategoricalValue}, opt::CSV.Options, row, col, state, ifnull::Function)
-    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifnull)
-    return v isa Missing ? ifnull(row, col) : v
+@inline function parsefield(io::IO, ::Type{<:CategoricalValue}, opt::CSV.Options, row, col, state, ifmissing::Function)
+    v = parsefield(io, WeakRefString{UInt8}, opt, row, col, state, ifmissing)
+    return v isa Missing ? ifmissing(row, col) : v
 end
 
 # Generic fallback
-@inline function parsefield(io::IO, T, opt::CSV.Options, row, col, state, ifnull::Function)
-    v = parsefield(io, String, opt, row, col, state, ifnull)
-    ismissing(v) && return ifnull(row, col)
-    T === Missing && throw(ParsingException("encountered non-null value for a null-only column on row = $row, col = $col: '$v'"))
+@inline function parsefield(io::IO, T, opt::CSV.Options, row, col, state, ifmissing::Function)
+    v = parsefield(io, String, opt, row, col, state, ifmissing)
+    ismissing(v) && return ifmissing(row, col)
+    T === Missing && throw(ParsingException("encountered non-missing value for a missing-only column on row = $row, col = $col: '$v'"))
     return parse(T, v)
 end

--- a/test/datastreams.jl
+++ b/test/datastreams.jl
@@ -1,4 +1,4 @@
-reload("Nulls"); reload("WeakRefStrings"); reload("DataStreams"); reload("CSV"); reload("DataStreamsIntegrationTests")
+reload("Missings"); reload("WeakRefStrings"); reload("DataStreams"); reload("CSV"); reload("DataStreamsIntegrationTests")
 # NamedTuples
 FILE = joinpath(DataStreamsIntegrationTests.DSTESTDIR, "randoms_small.csv")
 DF = CSV.read(FILE)

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -104,11 +104,11 @@ v = CSV.parsefield(io,Int)
 @test v === 1234567890
 
 io = IOBuffer("\\N")
-v = CSV.parsefield(io, Union{Int, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Int, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"\\N\"")
-@test_throws Missings.MissingException CSV.parsefield(io,Int,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Int,CSV.Options(missingstring="\\N"))
 
 end # @testset "Int"
 
@@ -201,10 +201,10 @@ v = CSV.parsefield(io,Int)
 @test v === 1234567890
 
 io = Buffer(IOBuffer("\\N"))
-@test_throws Missings.MissingException CSV.parsefield(io,Int,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Int,CSV.Options(missingstring="\\N"))
 
 io = Buffer(IOBuffer("\"\\N\""))
-v = CSV.parsefield(io, Union{Int, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Int, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 end # @testset "Int Custom IO"
 
@@ -324,10 +324,10 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === Inf
 
 io = Buffer(IOBuffer("\\N"))
-@test_throws Missings.MissingException CSV.parsefield(io,Float64,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Float64,CSV.Options(missingstring="\\N"))
 
 io = Buffer(IOBuffer("\"\\N\""))
-v = CSV.parsefield(io, Union{Float64, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Float64, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 end # @testset "Float64 Custom IO"
@@ -480,10 +480,10 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === Inf
 
 io = IOBuffer("\\N")
-@test_throws Missings.MissingException CSV.parsefield(io,Float64,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Float64,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\"\\N\"")
-v = CSV.parsefield(io, Union{Float64, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Float64, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 end # @testset "Float64"
@@ -602,11 +602,11 @@ v = CSV.parsefield(io,Dec64)
 @test v === Dec64(Inf)
 
 io = Buffer(IOBuffer("\\N"))
-v = CSV.parsefield(io, Union{Dec64, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Dec64, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = Buffer(IOBuffer("\"\\N\""))
-@test_throws Missings.MissingException CSV.parsefield(io,Dec64,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Dec64,CSV.Options(missingstring="\\N"))
 
 end # @testset "DecFP Custom IO"
 
@@ -724,10 +724,10 @@ v = CSV.parsefield(io, Union{Dec64, Missing})
 @test v === Dec64(Inf)
 
 io = IOBuffer("\\N")
-@test_throws Missings.MissingException CSV.parsefield(io,Dec64,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Dec64,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\"\\N\"")
-v = CSV.parsefield(io, Union{Dec64, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Dec64, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 end # @testset "DecFP"
@@ -834,10 +834,10 @@ v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
 @test v == "hey there\\\"quoted field\\\""
 
 io = IOBuffer("\\N")
-@test_throws Missings.MissingException CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\"\\N\"")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\"")
@@ -952,10 +952,10 @@ v = CSV.parsefield(io,String)
 @test v == "hey there\\\"quoted field\\\""
 
 io = Buffer(IOBuffer("\\N"))
-@test_throws Missings.MissingException CSV.parsefield(io,String,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,String,CSV.Options(missingstring="\\N"))
 
 io = Buffer(IOBuffer("\"\\N\""))
-v = CSV.parsefield(io, Union{String, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{String, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = Buffer(IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\""))
@@ -993,11 +993,11 @@ io = IOBuffer("\"\"")
 @test_throws Missings.MissingException CSV.parsefield(io,Date)
 
 io = IOBuffer("\\N")
-v = CSV.parsefield(io, Union{Date, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Date, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"\\N\"")
-@test_throws Missings.MissingException CSV.parsefield(io,Date,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Date,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("2015-10-05")
 v = CSV.parsefield(io, Date, opt)
@@ -1069,11 +1069,11 @@ io = Buffer(IOBuffer("\"\""))
 @test_throws Missings.MissingException CSV.parsefield(io,Date)
 
 io = Buffer(IOBuffer("\\N"))
-v = CSV.parsefield(io, Union{Date, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Date, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = Buffer(IOBuffer("\"\\N\""))
-@test_throws Missings.MissingException CSV.parsefield(io,Date,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Date,CSV.Options(missingstring="\\N"))
 
 io = Buffer(IOBuffer("2015-10-05"))
 v = CSV.parsefield(io,Date,opt)
@@ -1107,7 +1107,7 @@ v = CSV.parsefield(io,Date,opt)
 @test v === Date(2015,10,5)
 
 io = Buffer(IOBuffer("\"10/5/2015\"\n"))
-v = CSV.parsefield(io,Date,CSV.Options(null="",dateformat=Dates.DateFormat("mm/dd/yyyy")))
+v = CSV.parsefield(io,Date,CSV.Options(missingstring="",dateformat=Dates.DateFormat("mm/dd/yyyy")))
 @test v === Date(2015,10,5)
 
 end # @testset "Date Custom IO"
@@ -1136,11 +1136,11 @@ io = IOBuffer("\"\"")
 @test_throws Missings.MissingException CSV.parsefield(io,DateTime)
 
 io = IOBuffer("\\N")
-v = CSV.parsefield(io, Union{DateTime, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{DateTime, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"\\N\"")
-@test_throws Missings.MissingException CSV.parsefield(io,DateTime,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,DateTime,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("2015-10-05T00:00:01")
 v = CSV.parsefield(io,DateTime,opt)
@@ -1212,11 +1212,11 @@ io = Buffer(IOBuffer("\"\""))
 @test_throws Missings.MissingException CSV.parsefield(io,DateTime)
 
 io = Buffer(IOBuffer("\\N"))
-v = CSV.parsefield(io, Union{DateTime, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{DateTime, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = Buffer(IOBuffer("\"\\N\""))
-@test_throws Missings.MissingException CSV.parsefield(io,DateTime,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,DateTime,CSV.Options(missingstring="\\N"))
 
 io = Buffer(IOBuffer("2015-10-05T00:00:01"))
 v = CSV.parsefield(io,DateTime,opt)
@@ -1344,11 +1344,11 @@ io = IOBuffer("\"\"")
 @test_throws Missings.MissingException CSV.parsefield(io,Char)
 
 io = IOBuffer("\\N")
-v = CSV.parsefield(io, Union{Char, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Char, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"\\N\"")
-@test_throws Missings.MissingException CSV.parsefield(io,Char,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Char,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\t")
 v = CSV.parsefield(io, Union{Char, Missing}, CSV.Options(delim='\t'))
@@ -1411,11 +1411,11 @@ io = IOBuffer("\"\"")
 @test_throws Missings.MissingException CSV.parsefield(io,Bool)
 
 io = IOBuffer("\\N")
-v = CSV.parsefield(io, Union{Bool, Missing}, CSV.Options(null="\\N"))
+v = CSV.parsefield(io, Union{Bool, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"\\N\"")
-@test_throws Missings.MissingException CSV.parsefield(io,Bool,CSV.Options(null="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,Bool,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\t")
 v = CSV.parsefield(io, Union{Bool, Missing}, CSV.Options(delim='\t'))


### PR DESCRIPTION
In particular, rename the `null` argument to `missingstring` for consistency with
`truestring` and `falsestring`. This is breaking.

It would have been better to break things in 0.2.0, but better do it sooner than later.