### PR TITLE
remove datecheck in streamto! (fix #129)

### DIFF
--- a/src/Sink.jl
+++ b/src/Sink.jl
@@ -53,7 +53,7 @@ function Data.streamto!(sink::Sink, ::Type{Data.Field}, val::AbstractString, row
 end
 
 function Data.streamto!(sink::Sink, ::Type{Data.Field}, val::Dates.TimeType, row, col::Int)
-    v = sink.options.datecheck ? string(val) : Dates.format(val, sink.options.dateformat)
+    v = Dates.format(val, sink.options.dateformat)
     Base.write(sink.io, v, ifelse(col == sink.cols, NEWLINE, sink.options.delim))
     return nothing
 end


### PR DESCRIPTION
This removes the reference to `datecheck` which is not an existing field of `Options` (cf. #129).
If adding the field `datecheck` to `Options` is the preferred way to go, instead, I can gladly modifiy this PR.