### PR TITLE
Deduplicate column types detection code

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -3,7 +3,7 @@ module CSV
 
 using DataStreams, WeakRefStrings, Missings, CategoricalArrays, DataFrames
 
-using Compat, Compat.Mmap, Compat.Dates
+using Compat, Compat.Mmap, Compat.Dates, Compat.equalto
 
 struct ParsingException <: Exception
     msg::String

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -51,12 +51,12 @@ Keyword Arguments:
  * `quotechar::Union{Char,UInt8}`: the character that indicates a quoted field that may contain the `delim` or newlines; default `'"'`
  * `escapechar::Union{Char,UInt8}`: the character that escapes a `quotechar` in a quoted field; default `'\\'`
  * `missingstring::String`: indicates how missing values are represented in the dataset; default `""`
- * `dateformat::Union{AbstractString,Dates.DateFormat}`: how dates/datetimes are represented in the dataset; default `Base.Dates.ISODateTimeFormat`
+ * `dateformat::Union{Dates.DateFormat, Nothing}`: how dates/datetimes are represented in the dataset; default `Base.Dates.ISODateTimeFormat`
  * `decimal::Union{Char,UInt8}`: character to recognize as the decimal point in a float number, e.g. `3.14` or `3,14`; default `'.'`
  * `truestring`: string to represent `true::Bool` values in a csv file; default `"true"`. Note that `truestring` and `falsestring` cannot start with the same character.
  * `falsestring`: string to represent `false::Bool` values in a csv file; default `"false"`
 """
-struct Options{D}
+struct Options{D <: Union{DateFormat, Nothing}}
     delim::UInt8
     quotechar::UInt8
     escapechar::UInt8
@@ -112,9 +112,9 @@ CSV.reset!(source)
 sq1 = CSV.read(source, SQLite.Sink, db, "sqlite_table")
 ```
 """
-mutable struct Source{I, D} <: Data.Source
+mutable struct Source{I} <: Data.Source
     schema::Data.Schema
-    options::Options{D}
+    options::Options
     io::I
     fullpath::String
     datapos::Int # the position in the IOBuffer where the rows of data begins
@@ -136,9 +136,9 @@ performance gains as the resulting data set can be more consistently typed.
 
 Typical usage involves calling `CSV.read(file; transpose=true)`.
 """
-mutable struct TransposedSource{I, D} <: Data.Source
+mutable struct TransposedSource{I} <: Data.Source
     schema::Data.Schema
-    options::Options{D}
+    options::Options
     io::I
     fullpath::String
     datapos::Int # the position in the IOBuffer where the rows of data begins
@@ -166,8 +166,8 @@ CSV.reset!(source)
 sq1 = CSV.read(source, SQLite.Sink, db, "sqlite_table")
 ```
 """
-mutable struct Sink{D, B} <: Data.Sink
-    options::Options{D}
+mutable struct Sink{B} <: Data.Sink
+    options::Options
     io::IOBuffer
     fullpath::Union{String, IO}
     datapos::Int # the position in the IOBuffer where the rows of data begins

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -141,83 +141,11 @@ function Source(;fullpath::Union{AbstractString,IO}="",
         end
     end
 
-    # Detect column types
-    cols = length(columnnames)
-    if isa(types, Vector) && length(types) == cols
-        # types might be a Vector{DataType}, which will be a problem if Unions are needed
-        columntypes = convert(Vector{Type}, types)
-    elseif isa(types, Dict) || isempty(types)
-        columntypes = fill!(Vector{Type}(undef, cols), Any)
-        levels = [Dict{WeakRefString{UInt8}, Int}() for _ = 1:cols]
-        lineschecked = 0
-        while !eof(source) && lineschecked < min(rows < 0 ? rows_for_type_detect : rows, rows_for_type_detect)
-            lineschecked += 1
-            # println("type detecting on row = $lineschecked...")
-            for i = 1:cols
-                # print("\tdetecting col = $i...")
-                typ = CSV.detecttype(source, options, columntypes[i], levels[i])::Type
-                # print(typ)
-                columntypes[i] = CSV.promote_type2(columntypes[i], typ)
-                # println("...promoting to: ", columntypes[i])
-            end
-        end
-        if options.dateformat === nothing && any(x->Missings.T(x) <: Dates.TimeType, columntypes)
-            # auto-detected TimeType
-            options = Options(delim=options.delim, quotechar=options.quotechar, escapechar=options.escapechar,
-                              missingstring=options.missingstring, dateformat=Dates.ISODateTimeFormat, decimal=options.decimal,
-                              datarow=options.datarow, rows=options.rows, header=options.header, types=options.types)
-        end
-        if categorical
-            for i = 1:cols
-                T = columntypes[i]
-                if length(levels[i]) / sum(values(levels[i])) < .67 && T !== Missing && Missings.T(T) <: WeakRefString
-                    columntypes[i] = substitute(T, CategoricalArrays.catvaluetype(Missings.T(T), UInt32))
-                end
-            end
-        end
-    else
-        throw(ArgumentError("$cols number of columns detected; `types` argument has $(length(types)) entries"))
-    end
-    if isa(types, Dict)
-        if isa(types, Dict{String})
-            @static if VERSION >= v"0.7.0-DEV.3627"
-                colinds = indexin(keys(types), columnnames)
-            else
-                colinds = indexin(collect(keys(types)), columnnames)
-            end
-        else
-            colinds = keys(types)
-        end
-        for (col, typ) in zip(colinds, values(types))
-            columntypes[col] = typ
-        end
-        autocols = setdiff(1:cols, colinds)
-    elseif isempty(types)
-        autocols = collect(1:cols)
-    else
-        autocols = Int[]
-    end
-    if !weakrefstrings
-        columntypes = Type[(T !== Missing && Missings.T(T) <: WeakRefString) ? substitute(T, String) : T for T in columntypes]
-    end
-    if allowmissing != :auto
-        if allowmissing == :all # allow missing values in all automatically detected columns
-            for i = autocols
-                T = columntypes[i]
-                columntypes[i] = Union{Missings.T(T), Missing}
-            end
-        elseif allowmissing == :none # disallow missing values in all automatically detected columns
-            for i = autocols
-                T = columntypes[i]
-                columntypes[i] = Missings.T(T)
-            end
-        else
-            throw(ArgumentError("allowmissing must be either :all, :none or :auto"))
-        end
-    end
+    sch, fixed_options = detect_dataschema(source, columnnames, types, options,
+                            allowmissing, categorical, weakrefstrings,
+                            rows, rows_for_type_detect)
     seek(source, datapos)
-    sch = Data.Schema(columntypes, columnnames, ifelse(rows < 0, missing, rows))
-    return Source(sch, options, source, String(fullpath), datapos)
+    return Source(sch, fixed_options, source, String(fullpath), datapos)
 end
 
 # construct a new Source from a Sink

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -37,7 +37,7 @@ function Source(fullpath::Union{AbstractString,IO};
 end
 
 function Source(;fullpath::Union{AbstractString,IO}="",
-                options::CSV.Options{D}=CSV.Options(),
+                options::CSV.Options=CSV.Options(),
 
                 header::Union{Integer,UnitRange{Int},Vector}=1, # header can be a row number, range of rows, or actual string vector
                 datarow::Int=-1, # by default, data starts immediately after header or start of file
@@ -50,7 +50,7 @@ function Source(;fullpath::Union{AbstractString,IO}="",
                 footerskip::Int=0,
                 rows_for_type_detect::Int=100,
                 rows::Int=0,
-                use_mmap::Bool=true) where {D}
+                use_mmap::Bool=true)
     # argument checks
     isa(fullpath, AbstractString) && (isfile(fullpath) || throw(ArgumentError("\"$fullpath\" is not a valid file")))
     header = (isa(header, Integer) && header == 1 && datarow == 1) ? -1 : header

--- a/src/TransposedSource.jl
+++ b/src/TransposedSource.jl
@@ -37,7 +37,7 @@ function TransposedSource(fullpath::Union{AbstractString,IO};
 end
 
 function TransposedSource(;fullpath::Union{AbstractString,IO}="",
-                options::CSV.Options{D}=CSV.Options(),
+                options::CSV.Options=CSV.Options(),
 
                 header::Union{Integer,UnitRange{Int},Vector}=1, # header can be a row number, range of rows, or actual string vector
                 datarow::Int=-1, # by default, data starts immediately after header or start of file
@@ -50,7 +50,7 @@ function TransposedSource(;fullpath::Union{AbstractString,IO}="",
                 footerskip::Int=0,
                 rows_for_type_detect::Int=100,
                 rows::Int=0,
-                use_mmap::Bool=true) where {D}
+                use_mmap::Bool=true)
     # argument checks
     isa(fullpath, AbstractString) && (isfile(fullpath) || throw(ArgumentError("\"$fullpath\" is not a valid file")))
     header = (isa(header, Integer) && header == 1 && datarow == 1) ? -1 : header

--- a/src/io.jl
+++ b/src/io.jl
@@ -328,7 +328,7 @@ function detect_dataschema(source::IOBuffer, columnnames::AbstractVector{<:Abstr
             for i = 1:cols
                 T = columntypes[i]
                 if length(levels[i]) / sum(values(levels[i])) < .67 &&
-                    T !== Missing && Missings.T(T) <: WeakRefString
+                    T !== Missing && Missings.T(T) <: AbstractString
                     columntypes[i] = substitute(T, CategoricalArrays.catvaluetype(Missings.T(T), UInt32))
                 end
             end

--- a/src/io.jl
+++ b/src/io.jl
@@ -280,3 +280,98 @@ function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
     end
     return Missing
 end
+
+function detect_dataschema(source::IOBuffer, columnnames::AbstractVector{<:AbstractString}, types,
+                           options::Options, allowmissing::Symbol,
+                           categorical::Bool, weakrefstrings::Bool,
+                           rows::Integer, rows_for_type_detect::Integer,
+                           columnpositions::Union{AbstractVector{Int}, Nothing} = nothing)
+    cols = length(columnnames)
+    if isa(columnpositions, AbstractVector)
+        # vector of file positions for each column of the current row
+        columnpositions = deepcopy(columnpositions)
+    end
+    if isa(types, AbstractVector) && !isempty(types)
+        length(types) == cols || throw(ArgumentError("The length of types argument ($(length(types))) should match the number of columns ($cols)"))
+        # types might be a Vector{DataType}, which will be a problem if Unions are needed
+        columntypes = copy!(similar(types, Type), types)
+    elseif isa(types, Dict) || isempty(types)
+        columntypes = fill!(Vector{Type}(undef, cols), Any)
+        # FIXME copy options.types into columntypes and skip detection for user-specified columns
+        # FIXME skip detection completely if all columns have user-specified types
+        #println("starting column types detection...")
+        levels = [Dict{WeakRefString{UInt8}, Int}() for _ = 1:cols]
+        lineschecked = 0
+        rows_to_check = rows < 0 ? rows_for_type_detect : min(rows, rows_for_type_detect)
+        while !eof(source) && lineschecked < rows_to_check
+            lineschecked += 1
+            #println("type detection on row $lineschecked...")
+            for i = 1:cols
+                coltyp = columntypes[i]
+                #print("\tdetecting col #$i (current: $coltyp)...")
+                isa(columnpositions, AbstractVector) && seek(source, columnpositions[i]) # for TransposedSource
+                valtyp = CSV.detecttype(source, options, coltyp, levels[i])::Type
+                isa(columnpositions, AbstractVector) && (columnpositions[i] = position(source)) # for TransposedSource
+                #print("detected ", valtyp)
+                columntypes[i] = CSV.promote_type2(coltyp, valtyp)
+                #println("... promoted to: ", columntypes[i])
+                #coltyp != columntypes[i] && println("col #$i type old=$coltyp new=$(columntypes[i]) (row #$lineschecked type=$valtyp)")
+            end
+        end
+        if options.dateformat === nothing && any(x-> (x !== Missing) && (Missings.T(x) <: Dates.TimeType), columntypes)
+            # use the auto-detected format of the first TimeType column as the default for the whole table
+            options = Options(delim=options.delim, quotechar=options.quotechar, escapechar=options.escapechar,
+                              missingstring=options.missingstring, dateformat=Dates.ISODateTimeFormat, decimal=options.decimal,
+                              datarow=options.datarow, rows=options.rows, header=options.header, types=options.types)
+        end
+        if categorical
+            for i = 1:cols
+                T = columntypes[i]
+                if length(levels[i]) / sum(values(levels[i])) < .67 &&
+                    T !== Missing && Missings.T(T) <: WeakRefString
+                    columntypes[i] = substitute(T, CategoricalArrays.catvaluetype(Missings.T(T), UInt32))
+                end
+            end
+        end
+    else
+        throw(ArgumentError("$cols number of columns detected; `types` argument has $(length(types)) entries"))
+    end
+
+    # apply user-specified column types
+    if isempty(types)
+        autocols = collect(1:cols)
+    elseif isa(types, Dict)
+        autocols = collect(1:cols)
+        for (col, typ) in types
+            cix = col isa Integer ? col : findfirst(equalto(col), columnnames)
+            columntypes[cix] = typ
+            pos = searchsorted(autocols, cix)
+            isempty(pos) || deleteat!(autocols, first(pos))
+        end
+    else
+        @assert isa(types, Vector) && length(types) == cols
+        autocols = Int[]
+    end
+    if !weakrefstrings # replace WeakRefString column types with String
+        for (i, typ) in enumerate(columntypes)
+            if typ !== Missing && Missings.T(typ) <: WeakRefString
+                columntypes[i] = substitute(typ, String)
+            end
+        end
+    end
+    # handle missing values in automatically detected column types
+    if allowmissing == :all # allow missing values in all autodetected columns
+        for i in autocols
+            T = columntypes[i]
+            columntypes[i] = Union{Missings.T(T), Missing}
+        end
+    elseif allowmissing == :none # disallow missing values in all autodetected columns
+        for i in autocols
+            T = columntypes[i]
+            columntypes[i] = Missings.T(T)
+        end
+    elseif allowmissing != :auto
+        throw(ArgumentError("allowmissing must be either :all, :none or :auto"))
+    end
+    return Data.Schema(columntypes, columnnames, rows < 0 ? missing : rows), options
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -217,7 +217,7 @@ promote_type2(::Type{Missing}, ::Type{WeakRefString{UInt8}}) = Union{WeakRefStri
 promote_type2(::Type{Any}, ::Type{Missing}) = Missing
 promote_type2(::Type{Missing}, ::Type{Missing}) = Missing
 
-function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
+function detecttype(io, opt::CSV.Options, prevT, levels)
     pos = position(io)
     # update levels
     try
@@ -241,7 +241,7 @@ function detecttype(io, opt::CSV.Options{D}, prevT, levels) where {D}
         end
     end
     if Date <: prevT || DateTime <: prevT || prevT == Missing
-        if D == Nothing
+        if opt.dateformat === nothing
             # try to auto-detect TimeType
             try
                 seek(io, pos)

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -235,11 +235,11 @@ end
 
 function parsefield(io::IO, ::Type{Date}, opt::CSV.Options, row, col, state, ifmissing::Function)
     v = parsefield(io, String, opt, row, col, state, ifmissing)
-    return v isa Missing ? ifmissing(row, col) : Date(v, opt.dateformat)
+    return v isa Missing ? ifmissing(row, col) : Date(v, opt.dateformat === nothing ? Dates.ISODateFormat : opt.dateformat)
 end
 function parsefield(io::IO, ::Type{DateTime}, opt::CSV.Options, row, col, state, ifmissing::Function)
     v = parsefield(io, String, opt, row, col, state, ifmissing)
-    return v isa Missing ? ifmissing(row, col) : DateTime(v, opt.dateformat)
+    return v isa Missing ? ifmissing(row, col) : DateTime(v, opt.dateformat === nothing ? Dates.ISODateTimeFormat : opt.dateformat)
 end
 
 function parsefield(io::IO, ::Type{Char}, opt::CSV.Options, row, col, state, ifmissing::Function)


### PR DESCRIPTION
The column type detection code in `Source` and `TransposedSource` is identical (except file position updates), so I put it into `detect_dataschema()` function to reduce the overhead of keeping them in sync.

The CI might be broken, because it's also broken in master. I will update/fix the PR when the master is back to normal.