### PR TITLE
Revert addition of weakrefstrings option

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -15,7 +15,6 @@ function Source(fullpath::Union{AbstractString,IO};
               truestring="true",
               falsestring="false",
               categorical::Bool=true,
-              weakrefstrings::Bool=false,
 
               footerskip::Int=0,
               rows_for_type_detect::Int=20,
@@ -30,7 +29,7 @@ function Source(fullpath::Union{AbstractString,IO};
                                             quotechar=typeof(quotechar) <: String ? UInt8(first(quotechar)) : (quotechar % UInt8),
                                             escapechar=typeof(escapechar) <: String ? UInt8(first(escapechar)) : (escapechar % UInt8),
                                             null=null, dateformat=dateformat, decimal=decimal, truestring=truestring, falsestring=falsestring),
-                        header=header, datarow=datarow, types=types, nullable=nullable, categorical=categorical, weakrefstrings=weakrefstrings, footerskip=footerskip,
+                        header=header, datarow=datarow, types=types, nullable=nullable, categorical=categorical, footerskip=footerskip,
                         rows_for_type_detect=rows_for_type_detect, rows=rows, use_mmap=use_mmap)
 end
 
@@ -42,7 +41,6 @@ function Source(;fullpath::Union{AbstractString,IO}="",
                 types=Type[],
                 nullable::Union{Bool, Missing}=missing,
                 categorical::Bool=true,
-                weakrefstrings::Bool=false,
 
                 footerskip::Int=0,
                 rows_for_type_detect::Int=20,
@@ -179,9 +177,6 @@ function Source(;fullpath::Union{AbstractString,IO}="",
             c = findfirst(x->x == col, columnnames)
             columntypes[c] = typ
         end
-    end
-    if !weakrefstrings
-        columntypes = [T <: WeakRefString ? String : T for T in columntypes]
     end
     if !ismissing(nullable)
         if nullable # allow missing values in all columns


### PR DESCRIPTION
It broke tests, and has weird semantics since it completely overrides
explicit request for WeakRefString columns via the types argument.
This partly reverts commit ea2f215860dc0fec9eca09b1ea02763e683f5e80.