### PR TITLE
Convert `types::Vector{DataType}` to `types::Vector{Type}`

### DIFF
--- a/src/Source.jl
+++ b/src/Source.jl
@@ -131,7 +131,8 @@ function Source(;fullpath::Union{AbstractString,IO}="",
     # Detect column types
     cols = length(columnnames)
     if isa(types, Vector) && length(types) == cols
-        columntypes = types
+        # types might be a Vector{DataType}, which will be a problem if Unions are needed
+        columntypes = convert(Vector{Type}, types)
     elseif isa(types, Dict) || isempty(types)
         columntypes = fill!(Vector{Type}(uninitialized, cols), Any)
         levels = [Dict{WeakRefString{UInt8}, Int}() for _ = 1:cols]


### PR DESCRIPTION
When the `types` kwarg is passed in to `CSV.Source`, either a `Dict` or a `Vector{Type}` is expected, but `Vector{DataType}` resulted in an error.

Closes #150