### PR TITLE
Allow writing to IO as shown in examples

### DIFF
--- a/src/Sink.jl
+++ b/src/Sink.jl
@@ -1,4 +1,4 @@
-function Sink(fullpath::AbstractString;
+function Sink(fullpath::Union{AbstractString, IO};
               delim::Char=',',
               quotechar::Char='"',
               escapechar::Char='\\',
@@ -33,7 +33,7 @@ Data.streamtypes(::Type{CSV.Sink}) = [Data.Field]
 Data.weakrefstrings(::Type{CSV.Sink}) = true
 
 # Constructors
-function Sink(sch::Data.Schema, T, append, file::AbstractString; reference::Vector{UInt8}=UInt8[], kwargs...)
+function Sink(sch::Data.Schema, T, append, file::Union{AbstractString, IO}; reference::Vector{UInt8}=UInt8[], kwargs...)
     sink = Sink(file; append=append, colnames=Data.header(sch), kwargs...)
     return sink
 end
@@ -70,7 +70,7 @@ end
 function Data.close!(sink::CSV.Sink)
     io = isa(sink.fullpath, AbstractString) ? open(sink.fullpath, sink.append ? "a" : "w") : sink.fullpath
     Base.write(io, take!(sink.io))
-    applicable(close, io) && close(io)
+    isa(sink.fullpath, AbstractString) && close(io)
     return sink
 end
 
@@ -130,11 +130,11 @@ CSV.write("sqlite_table.csv", sqlite_source)
 """
 function write end
 
-function write(file::AbstractString, ::Type{T}, args...; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...) where {T}
+function write(file::Union{AbstractString, IO}, ::Type{T}, args...; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...) where {T}
     sink = Data.stream!(T(args...), CSV.Sink, file; append=append, transforms=transforms, kwargs...)
     return Data.close!(sink)
 end
-function write(file::AbstractString, source; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
+function write(file::Union{AbstractString, IO}, source; append::Bool=false, transforms::Dict=Dict{Int,Function}(), kwargs...)
     sink = Data.stream!(source, CSV.Sink, file; append=append, transforms=transforms, kwargs...)
     return Data.close!(sink)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ include("parsefields.jl")
 include("io.jl")
 
 include("source.jl")
+include("sink.jl")
 include("multistream.jl")
 include("validate.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,17 @@ if VERSION < v"0.7.0-DEV.2575"
 else
     using Dates
 end
+
+const dir = joinpath(dirname(@__FILE__),"test_files/")
+# dir = joinpath(Pkg.dir("CSV"), "test/test_files")
+
+@testset "CSV" begin
+
 include("parsefields.jl")
 include("io.jl")
-
-dir = joinpath(dirname(@__FILE__),"test_files/")
-# dir = joinpath(Pkg.dir("CSV"), "test/test_files")
 
 include("source.jl")
 include("multistream.jl")
 include("validate.jl")
+
+end

--- a/test/sink.jl
+++ b/test/sink.jl
@@ -1,0 +1,8 @@
+@testset "Write to IOBuffer" begin
+    csv_string = chomp(read(joinpath(dir, "test_basic.csv"), String))
+    df = CSV.read(IOBuffer(csv_string))
+    io = IOBuffer()
+    CSV.write(io, df)
+    written = chomp(String(take!(io)))
+    @test written == csv_string
+end


### PR DESCRIPTION
`CSV.write(io, df)` was in the examples for `CSV.write` but did not work. Now it does!

I changed `close!` to only close what it had opened. Closing an IOBuffer clears it, so `close!` would wipe the data. Given the functions had been changed to only allow file paths, and functionality for those doesn't change here, I think this won't have an impact on any existing uses.

Closes #155 