### PR TITLE
Set WeakRefStrings minimum version to v0.4.1

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.6
 DataStreams 0.3.0
 DataFrames 0.11.0
-WeakRefStrings 0.4.0
+WeakRefStrings 0.4.1
 CategoricalArrays 0.3.0
 Compat 0.41.0
 Missings


### PR DESCRIPTION
Alternatively we could just bump up the minimum version of WeakRefStrings that is required.