### PR TITLE
RFC: Restart parsing with a wider type when CSV.read fails

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -9,6 +9,25 @@ struct ParsingException <: Exception
     msg::String
 end
 
+struct ValueException <: Exception
+    T::Type
+    v::Any
+    row::Int
+    col::Int
+end
+
+function Base.showerror(io::IO, e::ValueException)
+    if e.T === Missing
+        print(io, "encountered non-missing value for a missing-only column on row = $row, col = $col: '$v'")
+    elseif e.T <: AbstractFloat && e.v isa Integer
+        print(io, "error parsing a `$(e.T)` value on column $(e.col), row $(e.row): ",
+                  "exponent out of range: $(e.exp)")
+    else
+        print(io, "error parsing a `$(e.T)` value on column $(e.col), row $(e.row): ",
+                  "encountered '$(e.v)'")
+    end
+end
+
 const RETURN  = UInt8('\r')
 const NEWLINE = UInt8('\n')
 const COMMA   = UInt8(',')

--- a/src/float.jl
+++ b/src/float.jl
@@ -61,12 +61,10 @@ const LITTLEY = UInt8('y')
 const BIGE = UInt8('E')
 const LITTLEE = UInt8('e')
 
-ParsingException(::Type{<:AbstractFloat}, exp::Signed, row, col) = ParsingException("error parsing a `$T` value on column $col, row $row; exponent out of range: $exp")
-
 function scale(exp, v::T, frac, row, col) where T
     if exp >= 0
         max_exp = maxexponent(T)
-        exp > max_exp && throw(ParsingException(T, exp, row, col))
+        exp > max_exp && throw(ValueException(T, exp, row, col))
         if exp > 15
             return Float64(Base.TwicePrecision{Float64}(v) * Base.TwicePrecision{Float64}(pow10(exp)))
         else
@@ -75,7 +73,7 @@ function scale(exp, v::T, frac, row, col) where T
     else
         min_exp = minexponent(T)
         if exp < min_exp
-            -exp + min_exp > -min_exp && throw(ParsingException(T, exp, row, col))
+            -exp + min_exp > -min_exp && throw(ValueException(T, exp, row, col))
             return Float64(Base.TwicePrecision{Float64}(v) / Base.TwicePrecision{Float64}(pow10(-exp + min_exp)))
         else
             if exp > 15
@@ -225,7 +223,7 @@ function parsefield(io::IO, ::Type{T}, opt::CSV.Options, row, col, state, ifmiss
     return ifmissing(row, col)
 
     @label error
-    throw(ParsingException(T, b, row, col))
+    throw(ValueException(T, b, row, col))
 end
 
 

--- a/src/parsefields.jl
+++ b/src/parsefields.jl
@@ -68,8 +68,6 @@ macro checkdone(label)
     end)
 end
 
-ParsingException(::Type{T}, b, row, col) where {T} = CSV.ParsingException("error parsing a `$T` value on column $col, row $row; encountered '$(Char(b))'")
-
 # as a last ditch effort, after we've trying parsing the correct type,
 # we check if the field is equal to a custom missing type
 # otherwise we give up and throw an error
@@ -164,7 +162,7 @@ function parsefield(io::IO, ::Type{T}, opt::CSV.Options, row, col, state, ifmiss
     return ifmissing(row, col)
 
     @label error
-    throw(ParsingException(T, b, row, col))
+    throw(ValueException(T, Char(b), row, col))
 end
 
 const BUF = IOBuffer()
@@ -258,7 +256,7 @@ function parsefield(io::IO, ::Type{Char}, opt::CSV.Options, row, col, state, ifm
     return ifmissing(row, col)
 
     @label error
-    throw(ParsingException(Char, b, row, col))
+    throw(ValueException(Char, Char(b), row, col))
 end
 
 function parsefield(io::IO, ::Type{Bool}, opt::CSV.Options, row, col, state, ifmissing::Function)
@@ -308,7 +306,7 @@ function parsefield(io::IO, ::Type{Bool}, opt::CSV.Options, row, col, state, ifm
     return ifmissing(row, col)
 
     @label error
-    throw(ParsingException(Bool, b, row, col))
+    throw(ValueException(Bool, Char(b), row, col))
 end
 
 function parsefield(io::IO, ::Type{<:Union{CategoricalValue, CategoricalString}}, opt::CSV.Options, row, col, state, ifmissing::Function)
@@ -320,6 +318,6 @@ end
 function parsefield(io::IO, T, opt::CSV.Options, row, col, state, ifmissing::Function)
     v = parsefield(io, String, opt, row, col, state, ifmissing)
     ismissing(v) && return ifmissing(row, col)
-    T === Missing && throw(ParsingException("encountered non-missing value for a missing-only column on row = $row, col = $col: '$v'"))
+    T === Missing && throw(ValueException(Missing, v, row, col))
     return parse(T, v)
 end

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -35,9 +35,9 @@ v = CSV.parsefield(io,Int)
 @test v === 2000
 
 io = IOBuffer("0.0")
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 io = IOBuffer("0a")
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 io = IOBuffer("")
 @test_throws Missings.MissingException v = CSV.parsefield(io,Int)
 @test ismissing(CSV.parsefield(IOBuffer(""), Union{Int, Missing}))
@@ -54,7 +54,7 @@ v = CSV.parsefield(io,Int)
 @test v === 10
 
 io = IOBuffer("\"1_00a0\"")
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 io = IOBuffer("\"0\"")
 v = CSV.parsefield(io,Int)
 @test v === 0
@@ -72,7 +72,7 @@ v = CSV.parsefield(io, Union{Int, Missing})
 @test v === 0
 
 io = IOBuffer("0a\n")
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 
 io = IOBuffer("\t0\t\n")
 v = CSV.parsefield(io, Union{Int, Missing})
@@ -133,9 +133,9 @@ v = CSV.parsefield(io,Int)
 @test v === 2000
 
 io = Buffer(IOBuffer("0.0"))
-@test_throws CSV.ParsingException CSV.parsefield(io, Union{Int, Missing})
+@test_throws CSV.ValueException CSV.parsefield(io, Union{Int, Missing})
 io = Buffer(IOBuffer("0a"))
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 io = Buffer(IOBuffer(""))
 v = CSV.parsefield(io, Union{Int, Missing})
 @test ismissing(v)
@@ -152,7 +152,7 @@ v = CSV.parsefield(io,Int)
 @test v === 10
 
 io = Buffer(IOBuffer("\"1_00a0\""))
-@test_throws CSV.ParsingException CSV.parsefield(io, Union{Int, Missing})
+@test_throws CSV.ValueException CSV.parsefield(io, Union{Int, Missing})
 io = Buffer(IOBuffer("\"0\""))
 v = CSV.parsefield(io,Int)
 @test v === 0
@@ -170,7 +170,7 @@ v = CSV.parsefield(io, Union{Int, Missing})
 @test v === 0
 
 io = Buffer(IOBuffer("0a\n"))
-@test_throws CSV.ParsingException CSV.parsefield(io,Int)
+@test_throws CSV.ValueException CSV.parsefield(io,Int)
 
 io = Buffer(IOBuffer("\t0\t\n"))
 v = CSV.parsefield(io, Union{Int, Missing})
@@ -231,7 +231,7 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === 2000.0
 
 io = Buffer(IOBuffer("0a"))
-@test_throws CSV.ParsingException CSV.parsefield(io,Float64)
+@test_throws CSV.ValueException CSV.parsefield(io,Float64)
 io = Buffer(IOBuffer(""))
 v = CSV.parsefield(io, Union{Float64, Missing})
 @test ismissing(v)
@@ -248,7 +248,7 @@ v = CSV.parsefield(io,Float64)
 @test v === 10.0
 
 io = Buffer(IOBuffer("\"1_00a0\""))
-@test_throws CSV.ParsingException CSV.parsefield(io, Union{Float64, Missing})
+@test_throws CSV.ValueException CSV.parsefield(io, Union{Float64, Missing})
 io = Buffer(IOBuffer("\"0\""))
 v = CSV.parsefield(io,Float64)
 @test v === 0.0
@@ -266,7 +266,7 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === 0.0
 
 io = Buffer(IOBuffer("0a\n"))
-@test_throws CSV.ParsingException CSV.parsefield(io,Float64)
+@test_throws CSV.ValueException CSV.parsefield(io,Float64)
 
 io = Buffer(IOBuffer("\t0\t\n"))
 v = CSV.parsefield(io, Union{Float64, Missing})
@@ -400,7 +400,7 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === 2000.0
 
 io = IOBuffer("0a")
-@test_throws CSV.ParsingException CSV.parsefield(io,Float64)
+@test_throws CSV.ValueException CSV.parsefield(io,Float64)
 io = IOBuffer("")
 v = CSV.parsefield(io, Union{Float64, Missing})
 @test ismissing(v)
@@ -417,7 +417,7 @@ v = CSV.parsefield(io,Float64)
 @test v === 10.0
 
 io = IOBuffer("\"1_00a0\"")
-@test_throws CSV.ParsingException CSV.parsefield(io, Union{Float64, Missing})
+@test_throws CSV.ValueException CSV.parsefield(io, Union{Float64, Missing})
 io = IOBuffer("\"0\"")
 v = CSV.parsefield(io,Float64)
 @test v === 0.0
@@ -435,7 +435,7 @@ v = CSV.parsefield(io, Union{Float64, Missing})
 @test v === 0.0
 
 io = IOBuffer("0a\n")
-@test_throws CSV.ParsingException CSV.parsefield(io,Float64)
+@test_throws CSV.ValueException CSV.parsefield(io,Float64)
 
 io = IOBuffer("\t0\t\n")
 v = CSV.parsefield(io, Union{Float64, Missing})
@@ -1476,12 +1476,12 @@ v = CSV.parsefield(io,Char)
 @test v === '1'
 
 io = IOBuffer("2000")
-@test_throws CSV.ParsingException CSV.parsefield(io,Char)
+@test_throws CSV.ValueException CSV.parsefield(io,Char)
 
 io = IOBuffer("0.0")
-@test_throws CSV.ParsingException CSV.parsefield(io,Char)
+@test_throws CSV.ValueException CSV.parsefield(io,Char)
 io = IOBuffer("0a")
-@test_throws CSV.ParsingException CSV.parsefield(io,Char)
+@test_throws CSV.ValueException CSV.parsefield(io,Char)
 io = IOBuffer("")
 v = CSV.parsefield(io, Union{Char, Missing})
 @test ismissing(v)
@@ -1498,7 +1498,7 @@ v = CSV.parsefield(io,Char)
 @test v === '0'
 
 io = IOBuffer("\"1_00a0\"")
-@test_throws CSV.ParsingException CSV.parsefield(io,Char)
+@test_throws CSV.ValueException CSV.parsefield(io,Char)
 io = IOBuffer("\"0\"")
 v = CSV.parsefield(io,Char)
 @test v === '0'
@@ -1516,7 +1516,7 @@ v = CSV.parsefield(io,Char)
 @test v === '0'
 
 io = IOBuffer("0a\n")
-@test_throws CSV.ParsingException CSV.parsefield(io,Char)
+@test_throws CSV.ValueException CSV.parsefield(io,Char)
 
 io = IOBuffer("\t0\t\n")
 v = CSV.parsefield(io,Char)
@@ -1584,7 +1584,7 @@ v = CSV.parsefield(io,Bool)
 @test v
 
 io = IOBuffer("truea\n")
-@test_throws CSV.ParsingException CSV.parsefield(io,Bool)
+@test_throws CSV.ValueException CSV.parsefield(io,Bool)
 
 io = IOBuffer("\ttrue\t\n")
 v = CSV.parsefield(io,Bool)

--- a/test/source.jl
+++ b/test/source.jl
@@ -154,7 +154,7 @@ ds = CSV.read(f)
 
 #test bad types
 f = CSV.Source(joinpath(dir, "test_float_in_int_column.csv"); types=[Int,Int,Int])
-@test_throws CSV.ParsingException CSV.read(f)
+@test_throws CSV.ValueException CSV.read(f)
 
 #test missing values
 f = CSV.Source(joinpath(dir, "test_missing_value_NULL.csv"); categorical=false, allowmissing=:auto)


### PR DESCRIPTION
Introduce a new `ValueException` type to distinguish errors due to an incorrect value from errors due to an incorrect file structure. Use its fields to widen type of the offending column in case of error and restart parsing.

This is a very preliminary implementation to get feedback on the approach. I think it's a good solution to avoid throwing errors which are terribly confusing/annoying for users (no other software does that AFAIK). Of course it can only work 1) for `CSV.read` and not `CSV.source`, since DataStreams needs to know the types beforehand, and 2) when the sink is a type rather than an object. But this covers the most typical use case, where CSV.jl is currently less practical to use than other software.

Areas to yet improve:
- [ ] Widen `Int` columns to `Float64` before using `String`.
- [ ] Take into account a user-provided `types` argument.
- [ ] Figure out whether it's OK to always call `seekstart`, or whether some streams don't support it.
- [ ] Improve logging: should we print something at all when restarting? more details about the problematic column?
- [ ] Add a `restart=true` keyword argument to allow disabling the new behavior.
- [ ] Also support widening columns which initially do not allow for missing values when `allowmissing=:auto`.

For a simple test of the new behavior: `CSV.read(IOBuffer("X\n1\na"), rows_for_type_detect=1)`.