### PR TITLE
Intern strings by default instead of using WeakRefString

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ DataFrames 0.11.0
 WeakRefStrings 0.4.1
 InternedStrings 0.6.0
 CategoricalArrays 0.3.0
-Compat 0.41.0
+Compat 0.50
 Missings

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,7 @@ julia 0.6
 DataStreams 0.3.0
 DataFrames 0.11.0
 WeakRefStrings 0.4.1
+InternedStrings 0.6.0
 CategoricalArrays 0.3.0
 Compat 0.41.0
 Missings

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -926,121 +926,256 @@ v = CSV.parsefield(io, Union{Dec64, Missing}, CSV.Options(missingstring="\\N"))
 
 end # @testset "DecFP"
 
+println("testing String")
+@testset "String" begin
+
+# String
+io = IOBuffer("0")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "0"
+
+io = IOBuffer("-1")
+v = CSV.parsefield(io,String)
+@test v == "-1"
+
+io = IOBuffer("1")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "1"
+
+io = IOBuffer("2000")
+v = CSV.parsefield(io,String)
+@test v == "2000"
+
+io = IOBuffer("0.0")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "0.0"
+
+io = IOBuffer("0a")
+v = CSV.parsefield(io,String)
+@test v == "0a"
+
+io = IOBuffer("")
+v = CSV.parsefield(io, Union{String, Missing})
+@test ismissing(v)
+
+io = IOBuffer(" ")
+v = CSV.parsefield(io,String)
+@test v == " "
+
+io = IOBuffer("\t")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "\t"
+
+io = IOBuffer(" \t 010")
+v = CSV.parsefield(io,String)
+@test v == " \t 010"
+
+io = IOBuffer("\"1_00a0\"")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "1_00a0"
+
+io = IOBuffer("\"0\"")
+v = CSV.parsefield(io,String)
+@test v == "0"
+
+io = IOBuffer("0\n")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "0"
+
+io = IOBuffer("0\r")
+v = CSV.parsefield(io,String)
+@test v == "0"
+
+io = IOBuffer("0\r\n")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "0"
+
+io = IOBuffer("0a\n")
+v = CSV.parsefield(io,String)
+@test v == "0a"
+
+io = IOBuffer("\t0\t\n")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "\t0\t"
+
+io = IOBuffer("0,")
+v = CSV.parsefield(io,String)
+@test v == "0"
+
+io = IOBuffer("0,\n")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "0"
+
+io = IOBuffer("\n")
+@test_throws Missings.MissingException CSV.parsefield(io,String)
+
+io = IOBuffer("\r")
+v = CSV.parsefield(io, Union{String, Missing})
+@test ismissing(v)
+
+io = IOBuffer("\r\n")
+@test_throws Missings.MissingException CSV.parsefield(io,String)
+
+io = IOBuffer("\"\"")
+v = CSV.parsefield(io, Union{String, Missing})
+@test ismissing(v)
+
+io = IOBuffer("1234567890")
+v = CSV.parsefield(io,String)
+@test v == "1234567890"
+
+io = IOBuffer("\"hey there\\\"quoted field\\\"\"")
+v = CSV.parsefield(io, Union{String, Missing})
+@test v == "hey there\\\"quoted field\\\""
+
+io = IOBuffer("\\N")
+@test_throws Missings.MissingException CSV.parsefield(io,String,CSV.Options(missingstring="\\N"))
+
+io = IOBuffer("\"\\N\"")
+v = CSV.parsefield(io, Union{String, Missing}, CSV.Options(missingstring="\\N"))
+@test ismissing(v)
+
+io = IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\"")
+v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
+@test v == "NORTH DAKOTA STATE \"\"A\"\" #1"
+
+io = IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\",")
+v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
+@test v == "NORTH DAKOTA STATE \"\"A\"\" #1"
+
+io = IOBuffer("a")
+v1 = CSV.parsefield(io, String)
+io = IOBuffer("a")
+v2 = CSV.parsefield(io, String)
+@test v1 isa String
+@test v1 == v2 == "a"
+@test v1 === v2
+
+io = IOBuffer("a")
+v1 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
+io = IOBuffer("a")
+v2 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
+@test v1 isa String
+@test v1 == v2 == "a"
+@test v1 !== v2
+
+end # @testset "String"
+
 println("testing WeakRefString")
 @testset "WeakRefString" begin
 
 # WeakRefString
 io = IOBuffer("0")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "0"
 
 io = IOBuffer("-1")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "-1"
 
 io = IOBuffer("1")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "1"
 
 io = IOBuffer("2000")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "2000"
 
 io = IOBuffer("0.0")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "0.0"
 
 io = IOBuffer("0a")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "0a"
 
 io = IOBuffer("")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test ismissing(v)
 
 io = IOBuffer(" ")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == " "
 
 io = IOBuffer("\t")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "\t"
 
 io = IOBuffer(" \t 010")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == " \t 010"
 
 io = IOBuffer("\"1_00a0\"")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "1_00a0"
 
 io = IOBuffer("\"0\"")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "0"
 
 io = IOBuffer("0\n")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "0"
 
 io = IOBuffer("0\r")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "0"
 
 io = IOBuffer("0\r\n")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "0"
 
 io = IOBuffer("0a\n")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "0a"
 
 io = IOBuffer("\t0\t\n")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "\t0\t"
 
 io = IOBuffer("0,")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "0"
 
 io = IOBuffer("0,\n")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "0"
 
 io = IOBuffer("\n")
-@test_throws Missings.MissingException CSV.parsefield(io,WeakRefString{UInt8})
+@test_throws Missings.MissingException CSV.parsefield(io,String)
 
 io = IOBuffer("\r")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test ismissing(v)
 
 io = IOBuffer("\r\n")
-@test_throws Missings.MissingException CSV.parsefield(io,WeakRefString{UInt8})
+@test_throws Missings.MissingException CSV.parsefield(io,String)
 
 io = IOBuffer("\"\"")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test ismissing(v)
 
 io = IOBuffer("1234567890")
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "1234567890"
 
 io = IOBuffer("\"hey there\\\"quoted field\\\"\"")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test v == "hey there\\\"quoted field\\\""
 
 io = IOBuffer("\\N")
-@test_throws Missings.MissingException CSV.parsefield(io,WeakRefString{UInt8},CSV.Options(missingstring="\\N"))
+@test_throws Missings.MissingException CSV.parsefield(io,String,CSV.Options(missingstring="\\N"))
 
 io = IOBuffer("\"\\N\"")
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing}, CSV.Options(missingstring="\\N"))
+v = CSV.parsefield(io, Union{String, Missing}, CSV.Options(missingstring="\\N"))
 @test ismissing(v)
 
 io = IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\"")
-v = CSV.parsefield(io, WeakRefString{UInt8}, CSV.Options(escapechar='"'))
+v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
 @test v == "NORTH DAKOTA STATE \"\"A\"\" #1"
 
 io = IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\",")
-v = CSV.parsefield(io, WeakRefString{UInt8}, CSV.Options(escapechar='"'))
+v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
 @test v == "NORTH DAKOTA STATE \"\"A\"\" #1"
 
 end # @testset "WeakRefString"
@@ -1161,6 +1296,24 @@ v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
 io = Buffer(IOBuffer("\"NORTH DAKOTA STATE \"\"A\"\" #1\","))
 v = CSV.parsefield(io, String, CSV.Options(escapechar='"'))
 @test v == "NORTH DAKOTA STATE \"\"A\"\" #1"
+
+io = Buffer(IOBuffer("a"))
+v1 = CSV.parsefield(io, String)
+io = Buffer(IOBuffer("a"))
+v2 = CSV.parsefield(io, String)
+@test v1 isa String
+@test v2 isa String
+@test v1 == v2 == "a"
+@test v1 === v2
+
+io = Buffer(IOBuffer("a"))
+v1 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
+io = Buffer(IOBuffer("a"))
+v2 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
+@test v1 isa String
+@test v2 isa String
+@test v1 == v2 == "a"
+@test v1 !== v2
 
 end # @testset "String Custom IO"
 
@@ -1659,7 +1812,7 @@ v = CSV.parsefield(io,Int)
 @test v === 1
 v = CSV.parsefield(io,Float64)
 @test v === 1.0
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "hey there sailor"
 v = CSV.parsefield(io,Date,opt)
 @test v === Date(2015,10,5)
@@ -1668,7 +1821,7 @@ v = CSV.parsefield(io, Union{Int, Missing})
 @test ismissing(v)
 v = CSV.parsefield(io,Float64)
 @test v === 1.0
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "hey there sailor"
 v = CSV.parsefield(io, Union{Date, Missing},opt)
 @test ismissing(v)
@@ -1677,7 +1830,7 @@ v = CSV.parsefield(io,Int)
 @test v === 1
 v = CSV.parsefield(io, Union{Float64, Missing})
 @test ismissing(v)
-v = CSV.parsefield(io,WeakRefString{UInt8})
+v = CSV.parsefield(io,String)
 @test v == "hey there sailor"
 v = CSV.parsefield(io,Date,opt)
 @test v === Date(2015,10,5)
@@ -1686,14 +1839,14 @@ v = CSV.parsefield(io,Int)
 @test v === 1
 v = CSV.parsefield(io,Float64)
 @test v === 1.0
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test ismissing(v)
 @test_throws Missings.MissingException CSV.parsefield(io,Date,opt)
 
 v = CSV.parsefield(io, Union{Int, Missing})
 @test ismissing(v)
 @test_throws Missings.MissingException CSV.parsefield(io,Float64)
-v = CSV.parsefield(io, Union{WeakRefString{UInt8}, Missing})
+v = CSV.parsefield(io, Union{String, Missing})
 @test ismissing(v)
 
 end # @testset "All types"

--- a/test/parsefields.jl
+++ b/test/parsefields.jl
@@ -1049,15 +1049,16 @@ io = IOBuffer("a")
 v2 = CSV.parsefield(io, String)
 @test v1 isa String
 @test v1 == v2 == "a"
-@test v1 === v2
+@test pointer(v1) == pointer(v2)
 
 io = IOBuffer("a")
 v1 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
 io = IOBuffer("a")
 v2 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
 @test v1 isa String
+@test v2 isa String
 @test v1 == v2 == "a"
-@test v1 !== v2
+@test pointer(v1) != pointer(v2)
 
 end # @testset "String"
 
@@ -1304,7 +1305,7 @@ v2 = CSV.parsefield(io, String)
 @test v1 isa String
 @test v2 isa String
 @test v1 == v2 == "a"
-@test v1 === v2
+@test pointer(v1) == pointer(v2)
 
 io = Buffer(IOBuffer("a"))
 v1 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
@@ -1313,7 +1314,7 @@ v2 = CSV.parsefield(io, String, CSV.Options(internstrings=false))
 @test v1 isa String
 @test v2 isa String
 @test v1 == v2 == "a"
-@test v1 !== v2
+@test pointer(v1) != pointer(v2)
 
 end # @testset "String Custom IO"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Compat
 using Missings
 using CSV
 using DataStreams, WeakRefStrings, CategoricalArrays

--- a/test/source.jl
+++ b/test/source.jl
@@ -88,7 +88,7 @@ f = CSV.Source(joinpath(dir, "test_quoted_delim_and_newline.csv"))
 @test size(Data.schema(f), 2) == 2
 @test size(Data.schema(f), 1) == 1
 
-f = CSV.Source(joinpath(dir, "test_quoted_numbers.csv"); categorical=false, allowmissing=:auto)
+f = CSV.Source(joinpath(dir, "test_quoted_numbers.csv"); categorical=false, strings=:weakref, allowmissing=:auto)
 @test size(Data.schema(f), 2) == 3
 @test size(Data.schema(f), 1) == 3
 ds = CSV.read(f)
@@ -160,7 +160,7 @@ f = CSV.Source(joinpath(dir, "test_float_in_int_column.csv"); types=[Int,Int,Int
 f = CSV.Source(joinpath(dir, "test_missing_value_NULL.csv"); categorical=false, allowmissing=:auto)
 @test size(Data.schema(f), 2) == 3
 @test size(Data.schema(f), 1) == 3
-@test Data.types(Data.schema(f)) == (Float64,WeakRefString{UInt8},Float64)
+@test Data.types(Data.schema(f)) == (Float64,String,Float64)
 ds = CSV.read(f)
 @test ds[1][1] == 1.0
 @test string(ds[2][1]) == "2.0"
@@ -344,14 +344,14 @@ df = CSV.read(joinpath(dir, "attenu.csv"), missingstring="NA", types=Dict(3=>Uni
 f = CSV.Source(joinpath(dir, "test_null_only_column.csv"), categorical=false, missingstring="NA", allowmissing=:auto)
 @test size(Data.schema(f)) == (3, 2)
 ds = CSV.read(f)
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8}, Missing)
+@test Data.types(Data.schema(f)) == (String, Missing)
 @test all(ismissing, ds[2])
 
 # #107
 df = CSV.read(IOBuffer("1,a,i\n2,b,ii\n3,c,iii"); datarow=1)
 @test size(df) == (3, 3)
 
-# #115 (Int64 -> Union{Int64, Missing} -> Union{WeakRefString, Missing} promotion)
+# #115 (Int64 -> Union{Int64, Missing} -> Union{String, Missing} promotion)
 df = CSV.read(joinpath(dir, "attenu.csv"), missingstring="NA", rows_for_type_detect=200, allowmissing=:auto)
 @test size(df) == (182, 5)
 @test Data.types(Data.schema(df)) == (Int64, Float64, Union{Missings.Missing, String}, Float64, Float64)
@@ -372,7 +372,7 @@ end # testset
 @testset "CSV.Source various files" begin
 
 #other various files found around the internet
-f = CSV.Source(joinpath(dir, "baseball.csv"); rows_for_type_detect=35)
+f = CSV.Source(joinpath(dir, "baseball.csv"); rows_for_type_detect=35, strings=:weakref)
 @test size(Data.schema(f), 2) == 15
 @test size(Data.schema(f), 1) == 35
 @test Data.header(Data.schema(f)) == ["Rk","Year","Age","Tm","Lg","","W","L","W-L%","G","Finish","Wpost","Lpost","W-L%post",""]
@@ -397,17 +397,17 @@ f = CSV.Source(joinpath(dir, "SacramentocrimeJanuary2006.csv"), allowmissing=:au
 @test size(Data.schema(f), 2) == 9
 @test size(Data.schema(f), 1) == 7584
 @test Data.header(Data.schema(f)) == ["cdatetime","address","district","beat","grid","crimedescr","ucr_ncic_code","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},WeakRefString{UInt8},Int64,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Float64,Float64)
+@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},String,Int64,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Float64,Float64)
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Sacramentorealestatetransactions.csv"), allowmissing=:auto)
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 985
 @test Data.header(Data.schema(f)) == ["street","city","zip","state","beds","baths","sq__ft","type","sale_date","price","latitude","longitude"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Int64,Int64,CategoricalString{UInt32},CategoricalString{UInt32},Int64,Float64,Float64)
+@test Data.types(Data.schema(f)) == (String,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Int64,Int64,CategoricalString{UInt32},CategoricalString{UInt32},Int64,Float64,Float64)
 ds = CSV.read(f)
 
-f = CSV.Source(joinpath(dir, "SalesJan2009.csv"); types=Dict(3=>WeakRefString{UInt8},7=>Union{WeakRefString{UInt8}, Missing}), allowmissing=:auto)
+f = CSV.Source(joinpath(dir, "SalesJan2009.csv"); types=Dict(3=>WeakRefString{UInt8},7=>Union{WeakRefString{UInt8}, Missing}), strings=:weakref, allowmissing=:auto)
 @test size(Data.schema(f), 2) == 12
 @test size(Data.schema(f), 1) == 998
 @test Data.header(Data.schema(f)) == ["Transaction_date","Product","Price","Payment_Type","Name","City","State","Country","Account_Created","Last_Login","Latitude","Longitude"]
@@ -418,14 +418,14 @@ f = CSV.Source(joinpath(dir, "stocks.csv"), allowmissing=:auto)
 @test size(Data.schema(f), 2) == 2
 @test size(Data.schema(f), 1) == 30
 @test Data.header(Data.schema(f)) == ["Stock Name","Company Name"]
-@test Data.types(Data.schema(f)) == (WeakRefString{UInt8},WeakRefString{UInt8})
+@test Data.types(Data.schema(f)) == (String,String)
 ds = CSV.read(f)
 
-f = CSV.Source(joinpath(dir, "TechCrunchcontinentalUSA.csv"); types=Dict(4=>Union{WeakRefString{UInt8}, Missing},5=>Union{WeakRefString{UInt8}, Missing}), allowmissing=:auto)
+f = CSV.Source(joinpath(dir, "TechCrunchcontinentalUSA.csv"); types=Dict(4=>Union{String, Missing},5=>Union{String, Missing}), allowmissing=:auto)
 @test size(Data.schema(f), 2) == 10
 @test size(Data.schema(f), 1) == 1460
 @test Data.header(Data.schema(f)) == ["permalink","company","numEmps","category","city","state","fundedDate","raisedAmt","raisedCurrency","round"]
-@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},CategoricalString{UInt32},Union{Int64, Missing},Union{WeakRefString{UInt8}, Missing},Union{WeakRefString{UInt8}, Missing},CategoricalString{UInt32},CategoricalString{UInt32},Int64,CategoricalString{UInt32},CategoricalString{UInt32})
+@test Data.types(Data.schema(f)) == (CategoricalString{UInt32},CategoricalString{UInt32},Union{Int64, Missing},Union{String, Missing},Union{String, Missing},CategoricalString{UInt32},CategoricalString{UInt32},Int64,CategoricalString{UInt32},CategoricalString{UInt32})
 ds = CSV.read(f)
 
 f = CSV.Source(joinpath(dir, "Fielding.csv"); allowmissing=:none, types=Dict("GS"=>Union{Int, Missing},"PO"=>Union{Int, Missing},"A"=>Union{Int, Missing},"E"=>Union{Int, Missing},"DP"=>Union{Int, Missing},"PB"=>Union{Int, Missing},"InnOuts"=>Union{Int, Missing},"WP"=>Union{Int, Missing},"SB"=>Union{Int, Missing},"CS"=>Union{Int, Missing},"ZR"=>Union{Int, Missing}))

--- a/test/source.jl
+++ b/test/source.jl
@@ -168,7 +168,7 @@ ds = CSV.read(f)
 f = CSV.Source(joinpath(dir, "test_missing_value_NULL.csv"); missingstring="NULL", allowmissing=:auto)
 @test size(Data.schema(f), 2) == 3
 @test size(Data.schema(f), 1) == 3
-@test String(f.options.missingstring) == "NULL"
+@test f.options.missingstring == codeunits("NULL")
 @test Data.types(Data.schema(f)) == (Float64,Union{Float64, Missing},Float64)
 ds = CSV.read(f)
 @test ds[1][1] == 1.0


### PR DESCRIPTION
`WeakRefString`s are dangerous in interaction with `use_mmap=true` since crashes can happen
if the file is modified during the lifetime of the resulting `DataFrame` (https://github.com/JuliaData/CSV.jl/issues/180). String interning can also be more efficient when the proportion of unique strings is small. Finally, returning plain `Vector{String}` columns is more user-friendly.

Ideally, DataFrames could take advantage of the fact that strings are interned to speed up grouping, which would allow using `categorical=false` by default.

A basic benchmark on 0.6 appears to indicate that interning is the fastest approach (not sure why the number of allocations is higher with `WeakRefString`):
```julia
julia> @btime CSV.read("test/test_files/Fielding.csv", strings=:intern, categorical=false, types=Dict("GS"=>Union{Int, Missing},"PO"=>Union{Int, Missing},"A"=>Union{Int, Missing},"E"=>Union{Int, Missing},"DP"=>Union{Int, Missing},"PB"=>Union{Int, Missing},"InnOuts"=>Union{Int, Missing},"WP"=>Union{Int, Missing},"SB"=>Union{Int, Missing},"CS"=>Union{Int, Missing},"ZR"=>Union{Int, Missing}), rows_for_type_detect=1);
  615.896 ms (10589390 allocations: 195.60 MiB)

julia> @btime CSV.read("CSV/test/test_files/Fielding.csv", strings=:weakref, categorical=false, types=Dict("GS"=>Union{Int, Missing},"PO"=>Union{Int, Missing},"A"=>Union{Int, Missing},"E"=>Union{Int, Missing},"DP"=>Union{Int, Missing},"PB"=>Union{Int, Missing},"InnOuts"=>Union{Int, Missing},"WP"=>Union{Int, Missing},"SB"=>Union{Int, Missing},"CS"=>Union{Int, Missing},"ZR"=>Union{Int, Missing}), rows_for_type_detect=1);
  675.738 ms (12563641 allocations: 255.85 MiB)

julia> @btime CSV.read("test/test_files/Fielding.csv", strings=:raw, categorical=false, types=Dict("GS"=>Union{Int, Missing},"PO"=>Union{Int, Missing},"A"=>Union{Int, Missing},"E"=>Union{Int, Missing},"DP"=>Union{Int, Missing},"PB"=>Union{Int, Missing},"InnOuts"=>Union{Int, Missing},"WP"=>Union{Int, Missing},"SB"=>Union{Int, Missing},"CS"=>Union{Int, Missing},"ZR"=>Union{Int, Missing}), rows_for_type_detect=1);
  725.674 ms (10589390 allocations: 195.60 MiB)
```