### PR TITLE
Rename ignore_repeated_delimiters argument to ignorerepeated

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -212,7 +212,7 @@ Supported keyword arguments include:
 * Parsing options:
   * `missingstrings`, `missingstring`: either a single, or Vector of Strings to use as sentinel values that will be parsed as `missing`, by default, only an empty field (two consecutive delimiters) is considered `missing`
   * `delim=','`: a character or string that indicates how columns are delimited in a file
-  * `ignore_repeated_delimiters=false`: whether repeated (consecutive) delimiters should be ignored while parsing; useful for fixed-width files with delimiter padding between cells
+  * `ignorerepeated=false`: whether repeated (consecutive) delimiters should be ignored while parsing; useful for fixed-width files with delimiter padding between cells
   * `quotechar='"'`, `openquotechar`, `closequotechar`: character (or different start and end characters) that indicate a quoted field which may contain textual delimiters or newline characters
   * `escapechar='\\'`: character used to escape quote characters in a text field
   * `dateformat`: a date format string to indicate how Date/DateTime columns are formatted in a delimited file
@@ -242,7 +242,7 @@ function File(source::Union{String, IO};
     missingstrings=String[],
     missingstring="",
     delim::Union{Char, String}=",",
-    ignore_repeated_delimiters::Bool=false,
+    ignorerepeated::Bool=false,
     quotechar::Union{UInt8, Char}='"',
     openquotechar::Union{UInt8, Char, Nothing}=nothing,
     closequotechar::Union{UInt8, Char, Nothing}=nothing,
@@ -271,7 +271,7 @@ function File(source::Union{String, IO};
     parsinglayers = Parsers.Sentinel(missingstrings) |>
                     x->Parsers.Strip(x, d == " " ? 0x00 : ' ', d == "\t" ? 0x00 : '\t') |>
                     (openquotechar !== nothing ? x->Parsers.Quoted(x, openquotechar, closequotechar, escapechar) : x->Parsers.Quoted(x, quotechar, escapechar)) |>
-                    x->Parsers.Delimited(x, d, "\n", "\r", "\r\n"; ignore_repeated=ignore_repeated_delimiters)
+                    x->Parsers.Delimited(x, d, "\n", "\r", "\r\n"; ignore_repeated=ignorerepeated)
 
     header = (isa(header, Integer) && header == 1 && (datarow == 1 || skipto == 1)) ? -1 : header
     isa(header, Integer) && datarow != -1 && (datarow > header || throw(ArgumentError("data row ($datarow) must come after header row ($header)")))

--- a/test/testfiles/testfiles.jl
+++ b/test/testfiles/testfiles.jl
@@ -391,7 +391,7 @@ testfiles = [
         NamedTuple{(:int, :bools), Tuple{Union{Missing, Int64}, Union{Missing, Bool}}},
         (int = Union{Missing, Int}[1, 2, 3, 4, 5, 6], bools = Union{Missing,Bool}[true, true, true, false, false, false])
     ),
-    ("test_repeated_delimiters.csv", (allowmissing=:auto, delim=" ", ignore_repeated_delimiters=true),
+    ("test_repeated_delimiters.csv", (allowmissing=:auto, delim=" ", ignorerepeated=true),
         (3, 5),
         NamedTuple{(:a, :b, :c, :d, :e), Tuple{Int64, Int64, Int64, Int64, Int64}},
         (a = [1, 1, 1], b = [2, 2, 2], c = [3, 3, 3], d = [4, 4, 4], e = [5, 5, 5])


### PR DESCRIPTION
That's consistent with other arguments, which don't use underscore, and it's easier to type.

See https://github.com/JuliaData/CSV.jl/pull/254#discussion_r214061557.