### PR TITLE
For small files, don't recompile anything

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -23,8 +23,6 @@ function Base.showerror(io::IO, e::Error)
     showerror(io, e.error)
 end
 
-# could just store NT internally and have Row take it as type parameter
-# could separate kwargs out into individual fields and remove type parameter
 struct File{transpose, columnaccess, I, P, KW}
     names::Vector{Symbol}
     types::Vector{Type}

--- a/src/filedetection.jl
+++ b/src/filedetection.jl
@@ -28,7 +28,7 @@ function makeunique(names)
         end
         push!(nms, nm)
     end
-    return Tuple(nms)
+    return nms
 end
 
 function skiptoheader!(parsinglayers, io, row, header)
@@ -106,7 +106,7 @@ function datalayout_transpose(header, parsinglayers, io, datarow, footerskip, no
         seek(io, datapos)
     end
     rows = rows - footerskip # rows now equals the actual number of rows in the dataset
-    return rows, makeunique(Tuple(normalizenames ? normalizename(x) : Symbol(x) for x in columnnames)), columnpositions
+    return rows, makeunique(map(x->normalizenames ? normalizename(x) : Symbol(x), columnnames)), columnpositions
 end
 
 function datalayout(header::Integer, parsinglayers, io, datarow, normalizenames)
@@ -117,10 +117,11 @@ function datalayout(header::Integer, parsinglayers, io, datarow, normalizenames)
         datapos = position(io)
         row_vals = readsplitline(parsinglayers, io)
         seek(io, datapos)
-        columnnames = Tuple(Symbol("Column$i") for i = eachindex(row_vals))
+        columnnames = [Symbol("Column$i") for i = eachindex(row_vals)]
     else
         skipto!(parsinglayers, io, 1, header)
-        columnnames = makeunique(Tuple(ismissing(x) ? Symbol("Column$i") : (normalizenames ? normalizename(x) : Symbol(x)) for (i, x) in enumerate(readsplitline(parsinglayers, io))))
+        # avoid recompilation here for every file w/ different # of columns?
+        columnnames = makeunique([ismissing(x) ? Symbol("Column$i") : (normalizenames ? normalizename(x) : Symbol(x)) for (i, x) in enumerate(readsplitline(parsinglayers, io))])
         datarow != header+1 && skipto!(parsinglayers, io, header+1, datarow)
         datapos = position(io)
     end
@@ -137,22 +138,22 @@ function datalayout(header::AbstractRange, parsinglayers, io, datarow, normalize
     end
     datarow != last(header)+1 && skipto!(parsinglayers, io, last(header)+1, datarow)
     datapos = position(io)
-    return makeunique(Tuple(normalizenames ? normalizename(nm) : Symbol(nm) for nm in columnnames)), datapos
+    return makeunique([normalizenames ? normalizename(nm) : Symbol(nm) for nm in columnnames]), datapos
 end
 
 function datalayout(header::Vector, parsinglayers, io, datarow, normalizenames)
     skipto!(parsinglayers, io, 1, datarow)
     datapos = position(io)
     if eof(io)
-        columnnames = makeunique(Tuple(normalizenames ? normalizename(nm) : Symbol(nm) for nm in header))
+        columnnames = makeunique([normalizenames ? normalizename(nm) : Symbol(nm) for nm in header])
     else
         row_vals = readsplitline(parsinglayers, io)
         seek(io, datapos)
         if isempty(header)
-            columnnames = Tuple(Symbol("Column$i") for i in eachindex(row_vals))
+            columnnames = [Symbol("Column$i") for i in eachindex(row_vals)]
         else
             length(header) == length(row_vals) || throw(ArgumentError("The length of provided header ($(length(header))) doesn't match the number of columns at row $datarow ($(length(row_vals)))"))
-            columnnames = makeunique(Tuple(normalizenames ? normalizename(nm) : Symbol(nm) for nm in header))
+            columnnames = makeunique([normalizenames ? normalizename(nm) : Symbol(nm) for nm in header])
         end
     end
     return columnnames, datapos

--- a/src/filedetection.jl
+++ b/src/filedetection.jl
@@ -120,7 +120,6 @@ function datalayout(header::Integer, parsinglayers, io, datarow, normalizenames)
         columnnames = [Symbol("Column$i") for i = eachindex(row_vals)]
     else
         skipto!(parsinglayers, io, 1, header)
-        # avoid recompilation here for every file w/ different # of columns?
         columnnames = makeunique([ismissing(x) ? Symbol("Column$i") : (normalizenames ? normalizename(x) : Symbol(x)) for (i, x) in enumerate(readsplitline(parsinglayers, io))])
         datarow != header+1 && skipto!(parsinglayers, io, header+1, datarow)
         datapos = position(io)

--- a/src/typedetection.jl
+++ b/src/typedetection.jl
@@ -34,11 +34,11 @@ promote_type2(::Type{String}, ::Type{String}) = String
 
 # providedtypes: Dict{String, Type}, Dict{Int, Type}, Vector{Type}
 initialtype(allowmissing) = (allowmissing === :auto || allowmissing === :none) ? Union{} : Missing
-initialtypes(T, ::Nothing, names) = Any[T for _ = 1:length(names)]
-initialtypes(T, t::Dict{String, V}, names) where {V} = Any[get(t, string(nm), T) for nm in names]
-initialtypes(T, t::Dict{Symbol, V}, names) where {V} = Any[get(t, nm, T) for nm in names]
-initialtypes(T, t::Dict{Int, V}, names) where {V} = Any[get(t, i, T) for i = 1:length(names)]
-initialtypes(T, t::Vector, names) = length(t) == length(names) ? collect(Any, t) : throw(ArgumentError("length of user provided types ($(length(t))) does not match length of header (?$(length(names)))"))
+initialtypes(T, ::Nothing, names) = Type[T for _ = 1:length(names)]
+initialtypes(T, t::Dict{String, V}, names) where {V} = Type[get(t, string(nm), T) for nm in names]
+initialtypes(T, t::Dict{Symbol, V}, names) where {V} = Type[get(t, nm, T) for nm in names]
+initialtypes(T, t::Dict{Int, V}, names) where {V} = Type[get(t, i, T) for i = 1:length(names)]
+initialtypes(T, t::Vector, names) = length(t) == length(names) ? collect(Type, t) : throw(ArgumentError("length of user provided types ($(length(t))) does not match length of header (?$(length(names)))"))
 
 struct Fib{N}
     len::Int

--- a/test/testfiles/testfiles.jl
+++ b/test/testfiles/testfiles.jl
@@ -1,4 +1,4 @@
-getschema(f::CSV.File{NT}) where NT = NT
+getschema(f::CSV.File) = NamedTuple{Tuple(f.names), Tuple{f.types...}}
 
 function testfile(file, kwargs, sz, sch, testfunc)
     f = CSV.File(file isa IO ? file : joinpath(dir, file); kwargs...)


### PR DESCRIPTION
This was a change I had wanted to experiment with and @tk3369 prompted the work by showing how much over-compiling was costing us in https://github.com/JuliaData/CSV.jl/issues/275. On the benchmarks we were running in that issue with this branch, we now see:
```julia
julia> perf()
2018-09-19T07:53:00.698 reading 50 x 1 file
  0.110446 seconds (112.06 k allocations: 5.198 MiB)
2018-09-19T07:53:00.928 reading 100 x 1 file
  0.005255 seconds (3.70 k allocations: 166.945 KiB)
2018-09-19T07:53:00.933 reading 150 x 1 file
  0.014252 seconds (5.58 k allocations: 237.680 KiB, 62.17% gc time)
2018-09-19T07:53:00.948 reading 200 x 1 file
  0.002573 seconds (7.96 k allocations: 361.148 KiB)
2018-09-19T07:53:00.95 reading 250 x 1 file
  0.002736 seconds (8.75 k allocations: 399.305 KiB)
2018-09-19T07:53:00.953 reading 300 x 1 file
  0.003196 seconds (10.42 k allocations: 461.695 KiB)
2018-09-19T07:53:00.957 reading 350 x 1 file
  0.003694 seconds (12.13 k allocations: 546.273 KiB)
2018-09-19T07:53:00.961 reading 400 x 1 file
  0.004209 seconds (13.83 k allocations: 612.805 KiB)
2018-09-19T07:53:00.965 reading 450 x 1 file
  0.006593 seconds (15.55 k allocations: 680.398 KiB)
2018-09-19T07:53:00.972 reading 500 x 1 file
  0.005080 seconds (17.29 k allocations: 747.898 KiB)
2018-09-19T07:53:00.978 reading 550 x 1 file
  0.005779 seconds (19.21 k allocations: 812.602 KiB)
2018-09-19T07:53:00.984 reading 600 x 1 file
  0.006613 seconds (23.38 k allocations: 1.069 MiB)
2018-09-19T07:53:00.99 reading 650 x 1 file
  0.006636 seconds (22.89 k allocations: 1.062 MiB)
2018-09-19T07:53:00.997 reading 700 x 1 file
  0.007651 seconds (24.83 k allocations: 1.130 MiB)
2018-09-19T07:53:01.005 reading 750 x 1 file
  0.007381 seconds (26.75 k allocations: 1.197 MiB)
2018-09-19T07:53:01.013 reading 800 x 1 file
  0.008498 seconds (28.70 k allocations: 1.266 MiB)
2018-09-19T07:53:01.022 reading 850 x 1 file
  0.009268 seconds (30.65 k allocations: 1.335 MiB)
2018-09-19T07:53:01.031 reading 900 x 1 file
  0.009300 seconds (32.60 k allocations: 1.404 MiB)
2018-09-19T07:53:01.041 reading 950 x 1 file
  0.012026 seconds (34.55 k allocations: 1.472 MiB)
2018-09-19T07:53:01.053 reading 1000 x 1 file
  0.009923 seconds (36.49 k allocations: 1.541 MiB)

```