### PR TITLE
Fix and improve CategoricalArray handling

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -35,7 +35,7 @@ struct File{transpose, columnaccess, I, P, KW}
     lastparsedcol::Base.RefValue{Int}
     lastparsedcode::Base.RefValue{Parsers.ReturnCode}
     kwargs::KW
-    pools::Vector{CategoricalPool{String, UInt32, CategoricalString{UInt32}}}
+    pools::Vector{CategoricalPool{String, UInt32, CatStr}}
     strict::Bool
 end
 
@@ -172,7 +172,13 @@ function File(source::Union{String, IO};
     end
 
     if types isa Vector
-        pools = CategoricalPool{String, UInt32, CatStr}[]
+        pools = Vector{CategoricalPool{String, UInt32, CatStr}}(undef, length(types))
+        for col = 1:length(types)
+            T = types[col]
+            if T !== Missing && Base.nonmissingtype(T) <: CatStr
+                pools[col] = CategoricalPool{String, UInt32}()
+            end
+        end
     else
         types, pools = detect(initialtypes(initialtype(allowmissing), types, names), io, positions, parsinglayers, kwargs, typemap, categorical, transpose, ref, debug)
         if allowmissing === :none

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -97,7 +97,7 @@ Supported keyword arguments include:
   * `types`: a Vector or Dict of types to be used for column types; a Dict can map column index `Int`, or name `Symbol` or `String` to type for a column, i.e. Dict(1=>Float64) will set the first column as a Float64, Dict(:column1=>Float64) will set the column named column1 to Float64 and, Dict("column1"=>Float64) will set the column1 to Float64
   * `typemap::Dict{Type, Type}`: a mapping of a type that should be replaced in every instance with another type, i.e. `Dict(Float64=>String)` would change every detected `Float64` column to be parsed as `Strings`
   * `allowmissing=:all`: indicate how missing values are allowed in columns; possible values are `:all` - all columns may contain missings, `:auto` - auto-detect columns that contain missings or, `:none` - no columns may contain missings
-  * `categorical::Bool=false`: whether columns with low cardinality (small number of unique values) should be read directly as a `CategoricalArray`
+  * `categorical::Bool=false`: whether columns detected as type `String` should be returned as a `CategoricalArray`
   * `strict::Bool=false`: whether invalid values should throw a parsing error or be replaced with missing values
 """
 function File(source::Union{String, IO};
@@ -283,7 +283,7 @@ Supported keyword arguments include:
   * `types`: a Vector or Dict of types to be used for column types; a Dict can map column index `Int`, or name `Symbol` or `String` to type for a column, i.e. Dict(1=>Float64) will set the first column as a Float64, Dict(:column1=>Float64) will set the column named column1 to Float64 and, Dict("column1"=>Float64) will set the column1 to Float64
   * `typemap::Dict{Type, Type}`: a mapping of a type that should be replaced in every instance with another type, i.e. `Dict(Float64=>String)` would change every detected `Float64` column to be parsed as `Strings`
   * `allowmissing=:all`: indicate how missing values are allowed in columns; possible values are `:all` - all columns may contain missings, `:auto` - auto-detect columns that contain missings or, `:none` - no columns may contain missings
-  * `categorical::Bool=false`: whether columns with low cardinality (small number of unique values) should be read directly as a `CategoricalArray`
+  * `categorical::Bool=false`: whether columns detected as `String` should be returned as a `CategoricalArray`
   * `strict::Bool=false`: whether invalid values should throw a parsing error or be replaced with missing values
 """
 function read end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -599,7 +599,13 @@ end
         return missing
     else
         @inbounds pool = source.pools[col]
-        return get🐱(pool, str::Tuple{Ptr{UInt8}, Int})
+        str::Tuple{Ptr{UInt8}, Int}
+        i = get(pool, str, nothing)
+        if i === nothing
+            i = get!(pool, unsafe_string(str[1], str[2]))
+            issorted(levels(pool)) || levels!(pool, sort(levels(pool)))
+        end
+        return CatStr(i, pool)
     end
 end
 

--- a/src/typedetection.jl
+++ b/src/typedetection.jl
@@ -99,8 +99,8 @@ function detect(types, io, positions, parsinglayers, kwargs, typemap, categorica
         pools = Vector{CategoricalPool{String, UInt32, CatStr}}(undef, cols)
         for col = 1:cols
             T = types[col]
-            if length(levels[col]) / sum(values(levels[col])) < .67 && T !== Missing && Base.nonmissingtype(T) <: String
-                types[col] = substitute(T, CategoricalArrays.catvaluetype(Base.nonmissingtype(T), UInt32))
+            if T === String || T === Union{String, Missing}
+                types[col] = substitute(T, CatStr)
                 pools[col] = CategoricalPool{String, UInt32}(collect(keys(levels[col])))
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,22 @@ end
     @test length(df) == 100000
 end
 
+@testset "CategoricalArray levels (including ordering)" begin
+    f = CSV.File(IOBuffer("X\nb\nc\na\nc"), types=[CategoricalString{UInt32}])
+    v = iterate(f, 1)[1].X
+    @test v == "b"
+    @test levels(v.pool) == ["b"]
+    v = iterate(f, 2)[1].X
+    @test v == "c"
+    @test levels(v.pool) == ["b", "c"]
+    v = iterate(f, 3)[1].X
+    @test v == "a"
+    @test levels(v.pool) == ["a", "b", "c"]
+    v = iterate(f, 4)[1].X
+    @test v == "c"
+    @test levels(v.pool) == ["a", "b", "c"]
+end
+
 include("deprecated.jl")
 
 end

--- a/test/testfiles/testfiles.jl
+++ b/test/testfiles/testfiles.jl
@@ -213,7 +213,7 @@ testfiles = [
     # other various files from around the interwebs
     ("baseball.csv", (categorical=true,),
         (35, 15),
-        NamedTuple{(:Rk, :Year, :Age, :Tm, :Lg, :Column6, :W, :L, :W_L_, :G, :Finish, :Wpost, :Lpost, :W_L_post, :Column15), Tuple{Union{Int64, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{CategoricalString{UInt32}, Missing},Union{CategoricalString{UInt32}, Missing},Union{String, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{CategoricalString{UInt32}, Missing}}},
+        NamedTuple{(:Rk, :Year, :Age, :Tm, :Lg, :Column6, :W, :L, :W_L_, :G, :Finish, :Wpost, :Lpost, :W_L_post, :Column15), Tuple{Union{Int64, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{CategoricalString{UInt32}, Missing},Union{CategoricalString{UInt32}, Missing},Union{CategoricalString{UInt32}, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{Int64, Missing},Union{Int64, Missing},Union{Float64, Missing},Union{CategoricalString{UInt32}, Missing}}},
         nothing
     ),
     ("FL_insurance_sample.csv", (types=Dict(10=>Float64,12=>Float64), allowmissing=:auto, categorical=true),
@@ -228,17 +228,17 @@ testfiles = [
     ),
     ("SacramentocrimeJanuary2006.csv", (allowmissing=:auto, categorical=true),
         (7584, 9),
-        NamedTuple{(:cdatetime, :address, :district, :beat, :grid, :crimedescr, :ucr_ncic_code, :latitude, :longitude),Tuple{String,String,Int64,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Float64,Float64}},
+        NamedTuple{(:cdatetime, :address, :district, :beat, :grid, :crimedescr, :ucr_ncic_code, :latitude, :longitude),Tuple{CategoricalString{UInt32},CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Float64,Float64}},
         nothing
     ),
     ("Sacramentorealestatetransactions.csv", (allowmissing=:auto, categorical=true, normalizenames=false),
         (985, 12),
-        NamedTuple{(:street, :city, :zip, :state, :beds, :baths, :sq__ft, :type, :sale_date, :price, :latitude, :longitude),Tuple{String,CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Int64,Int64,CategoricalString{UInt32},CategoricalString{UInt32},Int64,Float64,Float64}},
+        NamedTuple{(:street, :city, :zip, :state, :beds, :baths, :sq__ft, :type, :sale_date, :price, :latitude, :longitude),Tuple{CategoricalString{UInt32},CategoricalString{UInt32},Int64,CategoricalString{UInt32},Int64,Int64,Int64,CategoricalString{UInt32},CategoricalString{UInt32},Int64,Float64,Float64}},
         nothing
     ),
     ("SalesJan2009.csv", (allowmissing=:auto, categorical=true),
         (998, 12),
-        NamedTuple{(:Transaction_date, :Product, :Price, :Payment_Type, :Name, :City, :State, :Country, :Account_Created, :Last_Login, :Latitude, :Longitude),Tuple{String,CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},String,String,Union{Missing, CategoricalString{UInt32}},CategoricalString{UInt32},String,String,Float64,Float64}},
+        NamedTuple{(:Transaction_date, :Product, :Price, :Payment_Type, :Name, :City, :State, :Country, :Account_Created, :Last_Login, :Latitude, :Longitude),Tuple{CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},Union{Missing, CategoricalString{UInt32}},CategoricalString{UInt32},CategoricalString{UInt32},CategoricalString{UInt32},Float64,Float64}},
         nothing
     ),
     ("stocks.csv", (allowmissing=:auto,),


### PR DESCRIPTION
See commit messages. This should definitely be merged before tagging a release, since `CategoricalArray` handling is actually quite broken now. Also I think it's a good time to change the behavior of `categorical=true`.

Closes https://github.com/JuliaData/CSV.jl/issues/278.