### PR TITLE
Adjust the columns threshold based on various sized benchmark results

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -371,3 +371,31 @@ function Base.getproperty(csvrow::Row{F}, ::Type{T}, col::Int, name::Symbol) whe
     end
     return r
 end
+
+
+# code for generating various-sized csv files
+# used to determine the row vs. column-access threshold
+function gencsv(rows, cols)
+    df = DataFrame([round.(rand(rows), digits=4) for _ ∈ 1:cols], Symbol.(["col$i" for i ∈ 1:cols]))
+    CSV.write("random_$(rows)_$(cols).csv", df)
+end
+
+function go(compile=true)
+    # for cols in (10, 25, 50, 75, 100, 250)
+    #     for rows in (10, 50, 100, 1000, 5000, 10000, 50000, 100000)
+    #         println("generating $rows by $cols csv file...")
+    #         @time gencsv(rows, cols)
+    #     end
+    # end
+    rt = NamedTuple{(:compiled, :rows, :cols, :time), Tuple{Int, Int, Float64}}[]
+    for cols in (10, 25, 50, 75, 100, 250)
+        for rows in (10, 50, 100, 1000, 5000, 10000, 50000, 100000)
+            println("reading $rows by $cols csv file...")
+            e = @elapsed begin
+                df = CSV.File("random_$(rows)_$(cols).csv") |> DataFrame;
+            end
+            push!(rt, (compiled=compile, rows=rows, cols=cols, time=e))
+        end
+    end
+    CSV.write("results_$compile.csv", rt)
+end

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -168,7 +168,8 @@ function File(source::Union{String, IO};
         originalpositions = Int64[]
         footerskip > 0 && resize!(positions, length(positions) - footerskip)
         ref = Ref{Int}(0)
-        columnaccess = length(positions) <= 1024
+        # if the # of cells in the file is less than 500K
+        columnaccess = (length(names) * length(positions)) < 500_000
         debug && @show positions
     end
 


### PR DESCRIPTION
Ok, ran some experiments with various sized files; obviously there are some shortcomings to the approach here: it's tied to the performance characteristics of my laptop, I only tested Float64 columns, etc, etc. But this is at least more informed than the arbitrary threshold that was previously chosen. We can always refine things further later on.
<img width="1227" alt="screen shot 2018-09-25 at 10 21 21 pm" src="https://user-images.githubusercontent.com/2896623/46058467-846e5800-c118-11e8-9482-9fefea75e1ed.png">
