### PR TITLE
Allow passing proportion of unique values as categorical argument

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -97,7 +97,7 @@ Supported keyword arguments include:
   * `types`: a Vector or Dict of types to be used for column types; a Dict can map column index `Int`, or name `Symbol` or `String` to type for a column, i.e. Dict(1=>Float64) will set the first column as a Float64, Dict(:column1=>Float64) will set the column named column1 to Float64 and, Dict("column1"=>Float64) will set the column1 to Float64
   * `typemap::Dict{Type, Type}`: a mapping of a type that should be replaced in every instance with another type, i.e. `Dict(Float64=>String)` would change every detected `Float64` column to be parsed as `Strings`
   * `allowmissing=:all`: indicate how missing values are allowed in columns; possible values are `:all` - all columns may contain missings, `:auto` - auto-detect columns that contain missings or, `:none` - no columns may contain missings
-  * `categorical::Bool=false`: whether columns detected as type `String` should be returned as a `CategoricalArray`
+  * `categorical::Union{Bool, Real}=false`: if `true`, columns detected as `String` are returned as a `CategoricalArray`; alternatively, the proportion of unique values below which `String` columns should be treated as categorical (for example 0.1 for 10%)
   * `strict::Bool=false`: whether invalid values should throw a parsing error or be replaced with missing values
 """
 function File(source::Union{String, IO};
@@ -130,7 +130,7 @@ function File(source::Union{String, IO};
     types=nothing,
     typemap::Dict=EMPTY_TYPEMAP,
     allowmissing::Symbol=:all,
-    categorical::Bool=false,
+    categorical::Union{Bool, Real}=false,
     strict::Bool=false,
     debug::Bool=false,
     kw...)
@@ -285,7 +285,7 @@ Supported keyword arguments include:
   * `types`: a Vector or Dict of types to be used for column types; a Dict can map column index `Int`, or name `Symbol` or `String` to type for a column, i.e. Dict(1=>Float64) will set the first column as a Float64, Dict(:column1=>Float64) will set the column named column1 to Float64 and, Dict("column1"=>Float64) will set the column1 to Float64
   * `typemap::Dict{Type, Type}`: a mapping of a type that should be replaced in every instance with another type, i.e. `Dict(Float64=>String)` would change every detected `Float64` column to be parsed as `Strings`
   * `allowmissing=:all`: indicate how missing values are allowed in columns; possible values are `:all` - all columns may contain missings, `:auto` - auto-detect columns that contain missings or, `:none` - no columns may contain missings
-  * `categorical::Bool=false`: whether columns detected as `String` should be returned as a `CategoricalArray`
+  * `categorical::Union{Bool, Real}=false`: if `true`, columns detected as `String` are returned as a `CategoricalArray`; alternatively, the proportion of unique values below which `String` columns should be treated as categorical (for example 0.1 for 10%)
   * `strict::Bool=false`: whether invalid values should throw a parsing error or be replaced with missing values
 """
 function read end

--- a/src/typedetection.jl
+++ b/src/typedetection.jl
@@ -85,8 +85,10 @@ function detect(types, io, positions, parsinglayers, kwargs, typemap, categorica
         pools = Vector{CategoricalPool{String, UInt32, CatStr}}(undef, cols)
         for col = 1:cols
             T = types[col]
-            if (T === String || T === Union{String, Missing}) &&
-               (categorical === true || length(levels[col]) / sum(values(levels[col])) < categorical)
+            # FIXME: the first condition could be moved second for performance,
+            # but it triggers an inference bug in Julia 0.7 and 1.0
+            if (categorical === true || length(levels[col]) / sum(values(levels[col])) < categorical) &&
+               (T === String || T === Union{String, Missing})
                 types[col] = substitute(T, CatStr)
                 pools[col] = CategoricalPool{String, UInt32}(collect(keys(levels[col])))
             end

--- a/test/testfiles/testfiles.jl
+++ b/test/testfiles/testfiles.jl
@@ -209,7 +209,22 @@ testfiles = [
     ("categorical.csv", (categorical=true, allowmissing=:auto),
         (15, 1),
         NamedTuple{(:cat,), Tuple{CategoricalString{UInt32}}},
-        (cat = CategoricalVector{CategoricalString{UInt32}}(["a", "a", "a", "b", "b", "b", "b", "b", "b", "b", "c", "c", "c", "c", "a"]),)
+        (cat = ["a", "a", "a", "b", "b", "b", "b", "b", "b", "b", "c", "c", "c", "c", "a"],)
+    ),
+    ("categorical.csv", (categorical=0.3, allowmissing=:auto),
+        (15, 1),
+        NamedTuple{(:cat,), Tuple{CategoricalString{UInt32}}},
+        (cat = ["a", "a", "a", "b", "b", "b", "b", "b", "b", "b", "c", "c", "c", "c", "a"],)
+    ),
+    ("categorical.csv", (categorical=false, allowmissing=:auto),
+        (15, 1),
+        NamedTuple{(:cat,), Tuple{String}},
+        (cat = ["a", "a", "a", "b", "b", "b", "b", "b", "b", "b", "c", "c", "c", "c", "a"],)
+    ),
+    ("categorical.csv", (categorical=0.0, allowmissing=:auto),
+        (15, 1),
+        NamedTuple{(:cat,), Tuple{String}},
+        (cat = ["a", "a", "a", "b", "b", "b", "b", "b", "b", "b", "c", "c", "c", "c", "a"],)
     ),
     # other various files from around the interwebs
     ("baseball.csv", (categorical=true, normalizenames=true),


### PR DESCRIPTION
This can be convenient to avoid treating a `String` ID column as categorical, which is never a good idea.

Fixes https://github.com/JuliaData/CSV.jl/issues/314.

EDIT: the second commit works around this, which happens even on Julia master:
```julia
julia> CSV.read("test/testfiles/baseball.csv", categorical=true)
ERROR: fatal error in type inference (type bound)
Stacktrace:
 [1] detect(::Array{Type,1}, ::Base.GenericIOBuffer{Array{UInt8,1}}, ::Array{Int64,1}, ::Parsers.Delimited{false,Parsers.Quoted{Parsers.Strip{Parsers.Sentinel{typeof(Parsers.defaultparser),Parsers.Trie{0x00,false,missing,2,Tuple{}}}}},Parsers.Trie{0x00,false,missing,8,Tuple{Parsers.Trie{0x2c,true,missing,8,Tuple{}},Parsers.Trie{0x0a,true,missing,8,Tuple{}},Parsers.Trie{0x0d,true,missing,8,Tuple{Parsers.Trie{0x0a,true,missing,8,Tuple{}}}}}}}, ::NamedTuple{(),Tuple{}}, ::Dict{Type,Type}, ::Bool, ::Bool, ::Base.RefValue{Int64}, ::Bool) at /home/milan/.julia/dev/CSV/src/typedetection.jl:88
 [2] #File#1(::Int64, ::Bool, ::Int64, ::Nothing, ::Int64, ::Nothing, ::Bool, ::Nothing, ::Bool, ::Array{String,1}, ::String, ::String, ::Bool,::Char, ::Nothing, ::Nothing, ::Char, ::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Dict{Type,Type}, ::Symbol, ::Bool, ::Bool, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Type, ::String) at /home/milan/.julia/dev/CSV/src/CSV.jl:181
 [3] Type at ./none:0 [inlined]
 [4] #read#101(::Bool, ::Dict{Int64,Function}, ::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:categorical,),Tuple{Bool}}}, ::Function, ::String, ::Type) at /home/milan/.julia/dev/CSV/src/CSV.jl:304
 [5] #read at ./none:0 [inlined] (repeats 2 times)
 [6] top-level scope at none:0
```