### PR TITLE
don't force compiling on init

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -242,9 +242,6 @@ include("validate.jl")
 include("transforms.jl")
 
 function __init__()
-    # read a dummy file to "precompile" a bunch of methods; until the `precompile` function
-    # can propertly store machine code, this is our best option
-    CSV.File(joinpath(@__DIR__, "../test/testfiles/test_utf8.csv"), allowmissing=:auto) |> DataFrame
     Threads.resize_nthreads!(VALUE_BUFFERS)
     return
 end


### PR DESCRIPTION
There are many cases where CSV is loaded as a dependency for a package but is quite unlikely to be used at all in the session. The current strategy of compiling in `__init__` means that everyone has to pay that cost just to use CSV as a dependency. The fact that Julia has a compiler bundled is a strength of the language.

