### PR TITLE
Fix sorting of categorical levels

### DIFF
--- a/src/typedetection.jl
+++ b/src/typedetection.jl
@@ -124,7 +124,7 @@ function detect(types, io, positions, parsinglayers, kwargs, typemap, categorica
             if (categorical === true || (categorical !== false &&
                     length(levels[i]) / sum(values(levels[i])) < categorical)) && (T & STRING) > 0
                 S = T < 0 ? Union{CatStr, Missing} : CatStr
-                pools[i] = CategoricalPool{String, UInt32}(collect(keys(levels[i])))
+                pools[i] = CategoricalPool{String, UInt32}(sort!(collect(keys(levels[i]))))
             end
             @inbounds types[i] = get(typemap, S, S)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,20 @@ end
     v = iterate(f, 4)[1].X
     @test v == "c"
     @test levels(v.pool) == ["a", "b", "c"]
+
+    f = CSV.File(IOBuffer("X\nb\nc\na\nc"), categorical=true)
+    v = iterate(f, 1)[1].X
+    @test v == "b"
+    @test levels(v.pool) == ["a", "b", "c"]
+    v = iterate(f, 2)[1].X
+    @test v == "c"
+    @test levels(v.pool) == ["a", "b", "c"]
+    v = iterate(f, 3)[1].X
+    @test v == "a"
+    @test levels(v.pool) == ["a", "b", "c"]
+    v = iterate(f, 4)[1].X
+    @test v == "c"
+    @test levels(v.pool) == ["a", "b", "c"]
 end
 
 include("deprecated.jl")


### PR DESCRIPTION
When all levels have been found during type detection, they were not sorted since sorting was only performed when added a new level during iteration.