### PR TITLE
CSV.write enhancements

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -53,7 +53,11 @@ function bufferedwrite(io, x::AbstractFloat, df, decimal)
         print(io, "Inf")
         return false
     end
-    buffer = Base.Grisu.getbuf()
+    @static if VERSION < v"1.1.0"
+        buffer = Base.Grisu.DIGITSs[Threads.threadid()]
+    else
+        buffer = Base.Grisu.getbuf()
+    end
     len, pt, neg = Base.Grisu.grisu(x,Base.Grisu.SHORTEST,n,buffer)
     pdigits = pointer(buffer)
     e = pt-len

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,19 +1,22 @@
 """
-    CSV.write(file::Union{String, IO}, file; kwargs...) => file
-    table |> CSV.write(file::Union{String, IO}; kwargs...) => file
+    CSV.write(file, file; kwargs...) => file
+    table |> CSV.write(file; kwargs...) => file
 
-Write a [Tables.jl interface input](https://github.com/JuliaData/Tables.jl) to a csv file, given as an `IO` argument or String representing the file name to write to.
+Write a [Tables.jl interface input](https://github.com/JuliaData/Tables.jl) to a csv file, given as an `IO` argument or String/FilePaths.jl type representing the file name to write to.
 
 Keyword arguments include:
 * `delim::Union{Char, String}=','`: a character or string to print out as the file's delimiter
-* `quotechar::Char='"'`: character to use for quoting text fields that may contain delimiters or newlines
+* `quotechar::Char='"'`: ascii character to use for quoting text fields that may contain delimiters or newlines
 * `openquotechar::Char`: instead of `quotechar`, use `openquotechar` and `closequotechar` to support different starting and ending quote characters
-* `escapechar::Char='\\'`: character used to escape quote characters in a text field
+* `escapechar::Char='"'`: ascii character used to escape quote characters in a text field
 * `missingstring::String=""`: string to print 
 * `dateformat=Dates.default_format(T)`: the date format string to use for printing out Date & DateTime columns
 * `append=false`: whether to append writing to an existing file/IO, if `true`, it will not write column names by default
 * `writeheader=!append`: whether to write an initial row of delimited column names, not written by default if appending
 * `header`: pass a list of column names (Symbols or Strings) to use instead of the column names of the input table
+* `newline='\n'`: character or string to use to separate rows (lines in the csv file)
+* `quotestrings=false`: whether to force all strings to be quoted or not
+* `decimal='.'`: character to use as the decimal point when writing floating point numbers
 """
 function write end
 
@@ -38,7 +41,56 @@ function _reset(io::IOBuffer)
     io.size = 0
 end
 
-function bufferedwrite(io, val::Number, df)
+function bufferedwrite(io, x::AbstractFloat, df, decimal)
+    dot = false
+    n = 0
+    if isnan(x)
+        print(io, "NaN")
+        return false
+    end
+    x < 0 && print(io,'-')
+    if isinf(x)
+        print(io, "Inf")
+        return false
+    end
+    buffer = Base.Grisu.getbuf()
+    len, pt, neg = Base.Grisu.grisu(x,Base.Grisu.SHORTEST,n,buffer)
+    pdigits = pointer(buffer)
+    e = pt-len
+    k = -9<=e<=9 ? 1 : 2
+    if -pt > k+1 || e+dot > k+1
+        # => ########e###
+        unsafe_write(io, pdigits+0, len)
+        print(io, 'e')
+        print(io, string(e))
+        return false
+    elseif pt <= 0
+        # => 0.000########
+        print(io, "0$decimal")
+        while pt < 0
+            print(io, '0')
+            pt += 1
+        end
+        unsafe_write(io, pdigits+0, len)
+    elseif e >= dot
+        # => ########000.
+        unsafe_write(io, pdigits+0, len)
+        while e > 0
+            print(io, '0')
+            e -= 1
+        end
+        if dot
+            print(io, decimal)
+        end
+    else # => ####.####
+        unsafe_write(io, pdigits+0, pt)
+        print(io, decimal)
+        unsafe_write(io, pdigits+pt, len-pt)
+    end
+    return false
+end
+
+function bufferedwrite(io, val::Number, df, decimal)
     print(io, val)
     return false
 end
@@ -46,18 +98,19 @@ end
 getvalue(x, df) = x
 getvalue(x::T, df) where {T <: Dates.TimeType} = Dates.format(x, df === nothing ? Dates.default_format(T) : df)
 
-function bufferedwrite(io, val, df)
+function bufferedwrite(io, val, df, decimal)
     VALUE_BUFFER = VALUE_BUFFERS[Threads.threadid()]
     _reset(VALUE_BUFFER)
     print(VALUE_BUFFER, getvalue(val, df))
     return true
 end
 
-function bufferedescape(io, delim, oq, cq, e)
+function bufferedescape(io, delim, oq, cq, e, newline, quotestrings)
     VALUE_BUFFER = VALUE_BUFFERS[Threads.threadid()]
     n = position(VALUE_BUFFER)
     n == 0 && return
-    needtoescape, needtoquote = check(n, delim, oq, cq)
+    needtoescape, needtoquote = check(n, delim, oq, cq, newline)
+    needtoquote |= quotestrings
     seekstart(VALUE_BUFFER)
     if (needtoquote | needtoescape)
         if needtoescape
@@ -81,70 +134,105 @@ function bufferedescape(io, delim, oq, cq, e)
     return
 end
 
-function check(n, delim::Char, oq, cq)
+function check(n, delim::Char, oq, cq, newline::Char)
+    needtoescape = false
+    buf = VALUE_BUFFERS[Threads.threadid()].data
+    @inbounds needtoquote = buf[1] === oq
+    d = delim % UInt8
+    new = newline % UInt8
+    @simd for i = 1:n
+        @inbounds b = buf[i]
+        needtoquote |= (b === d) | (b === new)
+        needtoescape |= b === cq
+    end
+    return needtoescape, needtoquote
+end
+
+function check(n, delim::Char, oq, cq, newline::String)
     needtoescape = false
     buf = VALUE_BUFFERS[Threads.threadid()].data
     @inbounds needtoquote = buf[1] === oq
     d = delim % UInt8
     @simd for i = 1:n
         @inbounds b = buf[i]
-        needtoquote |= (b === d) | (b === UInt8('\n')) | (b === UInt8('\r'))
+        needtoquote |= b === d
         needtoescape |= b === cq
     end
+    needtoquote |= occursin(newline, String(buf[1:n]))
     return needtoescape, needtoquote
 end
 
-function check(n, delim::String, oq, cq)
+function check(n, delim::String, oq, cq, newline::Char)
     needtoescape = false
     buf = VALUE_BUFFERS[Threads.threadid()].data
     @inbounds needtoquote = buf[1] === oq
+    new = newline % UInt8
     @simd for i = 1:n
         @inbounds b = buf[i]
-        needtoquote |= (b === UInt8('\n')) | (b === UInt8('\r'))
+        needtoquote |= b === new
         needtoescape |= b === cq
     end
     needtoquote |= occursin(delim, String(buf[1:n]))
     return needtoescape, needtoquote
 end
 
-write(file::Union{String, IO}; kwargs...) = x->write(file, x; kwargs...)
-function write(file::Union{String, IO}, itr; kwargs...)
-    rows = Tables.rows(itr)
-    sch = Tables.schema(rows)
-    return write(sch, rows, file; kwargs...)
+function check(n, delim::String, oq, cq, newline::String)
+    needtoescape = false
+    buf = VALUE_BUFFERS[Threads.threadid()].data
+    @inbounds needtoquote = buf[1] === oq
+    @simd for i = 1:n
+        @inbounds b = buf[i]
+        needtoescape |= b === cq
+    end
+    str = String(buf[1:n])
+    needtoquote |= occursin(delim, str)
+    needtoquote |= occursin(newline, str)
+    return needtoescape, needtoquote
 end
 
-function printheader(io, header, delim, oq, cq, e, df)
+write(file; kwargs...) = x->write(file, x; kwargs...)
+function write(file, itr;
+    quotechar::Char='"',
+    openquotechar::Union{Char, Nothing}=nothing,
+    closequotechar::Union{Char, Nothing}=nothing,
+    escapechar::Char='"',
+    newline::Union{Char, String}='\n',
+    decimal::Char='.',
+    kwargs...)
+    (isascii(something(openquotechar, quotechar)) && isascii(something(closequotechar, quotechar)) && isascii(escapechar)) || throw(ArgumentError("quote and escape characters must be ASCII characters "))
+    oq, cq = openquotechar !== nothing ? (openquotechar % UInt8, closequotechar % UInt8) : (quotechar % UInt8, quotechar % UInt8)
+    e = escapechar % UInt8
+    rows = Tables.rows(itr)
+    sch = Tables.schema(rows)
+    return write(sch, rows, file, oq, cq, e, newline, decimal; kwargs...)
+end
+
+function printheader(io, header, delim, oq, cq, e, newline)
     cols = length(header)
     for (col, nm) in enumerate(header)
-        bufferedwrite(io, string(nm), nothing) && bufferedescape(io, delim, oq, cq, e)
-        Base.write(io, ifelse(col == cols, UInt8('\n'), delim))
+        bufferedwrite(io, string(nm), nothing, UInt8('.')) && bufferedescape(io, delim, oq, cq, e, newline, false)
+        Base.write(io, ifelse(col == cols, newline, delim))
     end
     return
 end
 
-function write(sch::Tables.Schema{schema_names}, rows, file::Union{String, IO};
+function write(sch::Tables.Schema{names}, rows, file, oq, cq, e, newline, decimal;
     delim::Union{Char, String}=',',
-    quotechar::Char='"',
-    openquotechar::Union{Char, Nothing}=nothing,
-    closequotechar::Union{Char, Nothing}=nothing,
-    escapechar::Char='\\',
     missingstring::AbstractString="",
     dateformat=nothing,
     append::Bool=false,
     writeheader::Bool=!append,
     header::Vector=String[],
-    kwargs...) where {schema_names}
-    oq, cq = openquotechar !== nothing ? (openquotechar % UInt8, closequotechar % UInt8) : (quotechar % UInt8, quotechar % UInt8)
-    e = escapechar % UInt8
-    names = isempty(header) ? schema_names : header
-    cols = length(names)
+    quotestrings::Bool=false,
+    kwargs...) where {names}
+    colnames = isempty(header) ? names : header
+    cols = length(colnames)
     with(file, append) do io
-        writeheader && printheader(io, names, delim, oq, cq, escapechar, dateformat)
+        writeheader && printheader(io, colnames, delim, oq, cq, e, newline)
         for row in rows
             Tables.eachcolumn(sch, row) do val, col, nm
-                bufferedwrite(io, coalesce(val, missingstring), dateformat) && bufferedescape(io, delim, oq, cq, e)
-                Base.write(io, ifelse(col == cols, UInt8('\n'), delim))
+                bufferedwrite(io, coalesce(val, missingstring), dateformat, decimal) && bufferedescape(io, delim, oq, cq, e, newline, quotestrings)
+                Base.write(io, ifelse(col == cols, newline, delim))
             end
         end
     end
@@ -152,25 +240,20 @@ function write(sch::Tables.Schema{schema_names}, rows, file::Union{String, IO};
 end
 
 # handle unknown schema case
-function write(::Nothing, rows, file::Union{String, IO};
+function write(::Nothing, rows, file, oq, cq, e, newline, decimal;
     delim::Union{Char, String}=',',
-    quotechar::Char='"',
-    openquotechar::Union{Char, Nothing}=nothing,
-    closequotechar::Union{Char, Nothing}=nothing,
-    escapechar::Char='\\',
     missingstring::AbstractString="",
     dateformat=nothing,
     append::Bool=false,
     writeheader::Bool=!append,
     header::Vector=String[],
+    quotestrings::Bool=false,
     kwargs...)
-    oq, cq = openquotechar !== nothing ? (openquotechar % UInt8, closequotechar % UInt8) : (quotechar % UInt8, quotechar % UInt8)
-    e = escapechar % UInt8
     state = iterate(rows)
     if state === nothing
         if writeheader && !isempty(header)
             with(file, append) do io
-                printheader(io, header, delim, oq, cq, escapechar, dateformat)
+                printheader(io, header, delim, oq, cq, e, newline)
             end
         end
         return file
@@ -180,11 +263,11 @@ function write(::Nothing, rows, file::Union{String, IO};
     sch = Tables.Schema(names, nothing)
     cols = length(names)
     with(file, append) do io
-        writeheader && printheader(io, names, delim, oq, cq, escapechar, dateformat)
+        writeheader && printheader(io, names, delim, oq, cq, e, newline)
         while true
             Tables.eachcolumn(sch, row) do val, col, nm
-                bufferedwrite(io, coalesce(val, missingstring), dateformat) && bufferedescape(io, delim, oq, cq, e)
-                Base.write(io, ifelse(col == cols, UInt8('\n'), delim))
+                bufferedwrite(io, coalesce(val, missingstring), dateformat, decimal) && bufferedescape(io, delim, oq, cq, e, newline, quotestrings)
+                Base.write(io, ifelse(col == cols, newline, delim))
             end
             state = iterate(rows, st)
             state === nothing && break


### PR DESCRIPTION
* Add `decimal` keyword argument to support custom float printing (fixes #385)
* Add additional validation of quote/escape character arguments (fixes #369)
* Add `quotestrings` keyword argument to support forcing all strings to be quoted (fixes #362)
* Add `newline` keyword argument to support a custom row separator (fixes #375, supersedes #376)
* Changes default `escapechar` to `'"'` to align w/ the default in `CSV.read`

This also removes the `file` restriction in light of #405 to allow passing a FilePaths.jl type instead of file name (cc: @oxinabox)