### PR TITLE
Refactor parseempty, parsemissing, and detecttype to avoid allocation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@
 
 ## Installation
 
-The package is registered in `METADATA.jl` and so can be installed with `Pkg.add`.
-
-```julia
-julia> Pkg.add("CSV")
-```
+The package is registered in the [`General`](https://github.com/JuliaRegistries/General) registry and so can be installed at the REPL with `] add CSV`.
 
 ## Documentation
 
@@ -23,14 +19,12 @@ julia> Pkg.add("CSV")
 
 ## Project Status
 
-The package is tested against Julia `0.7`, `1.0` and nightly on Linux, OS X, and Windows.
+The package is tested against Julia `1.0`, `1.1` and nightly on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
 Contributions are very welcome, as are feature requests and suggestions. Please open an
 [issue][issues-url] if you encounter any problems or would just like to ask a question.
-
-
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://JuliaData.github.io/CSV.jl/latest

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -84,14 +84,14 @@ function finalcolumn(col, T, buf, QS, escapedstrings, refs, i, pool, categorical
     end
 end
 
-function setchunk!(A, row, chunkrows, tape, tapeidx, ncol, f)
+@inline function setchunk!(A, row, chunkrows, tape, tapeidx, ncol, f)
     for rowoff = 0:chunkrows
         @inbounds A[row + rowoff] = f(tape[tapeidx + (rowoff * ncol * 2) + 1])
     end
     return
 end
 
-function setchunk!(A::Vector{Float64}, row, chunkrows, tape, tapeidx, ncol, f)
+@inline function setchunk!(A::Vector{Float64}, row, chunkrows, tape, tapeidx, ncol, f)
     for rowoff = 0:chunkrows
         @inbounds offlen = tape[tapeidx + (rowoff * ncol * 2)]
         @inbounds x = tape[tapeidx + (rowoff * ncol * 2) + 1]
@@ -100,7 +100,7 @@ function setchunk!(A::Vector{Float64}, row, chunkrows, tape, tapeidx, ncol, f)
     return
 end
 
-function setchunkm!(A, row, chunkrows, tape, tapeidx, ncol, f)
+@inline function setchunkm!(A, row, chunkrows, tape, tapeidx, ncol, f)
     for rowoff = 0:chunkrows
         @inbounds offlen = tape[tapeidx + (rowoff * ncol * 2)]
         @inbounds A[row + rowoff] = missingvalue(offlen) ? missing : f(tape[tapeidx + (rowoff * ncol * 2) + 1])
@@ -108,7 +108,7 @@ function setchunkm!(A, row, chunkrows, tape, tapeidx, ncol, f)
     return
 end
 
-function setchunkm!(A::Vector{Union{Missing, Float64}}, row, chunkrows, tape, tapeidx, ncol, f)
+@inline function setchunkm!(A::Vector{Union{Missing, Float64}}, row, chunkrows, tape, tapeidx, ncol, f)
     for rowoff = 0:chunkrows
         @inbounds offlen = tape[tapeidx + (rowoff * ncol * 2)]
         if !missingvalue(offlen)


### PR DESCRIPTION
…s and speed things up a bit. It was really only a problem in very large files that had all-missing columns where detecttype was being called for every value in the column. We now avoid any allocations in these type detection scenarios.