### PR TITLE
Refactor CSV.Column a bit

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -287,7 +287,7 @@ function file(source,
         typecodes[i] &= ~USER
     end
     finaltypes = Type[TYPECODES[T] for T in typecodes]
-    debug && println("types after parsing: $types")
+    debug && println("types after parsing: $finaltypes")
     finalrefs = Vector{Vector{String}}(undef, ncols)
     if pool > 0.0
         for i = 1:ncols
@@ -363,7 +363,7 @@ function parsetape(::Val{transpose}, ncols, typemap, tapes, tapelen, buf, pos, l
             end
             tapeidx += 2
             pos > len && break
-            if tapeidx > tapelen
+            if tapeidx + 1 > tapelen
                 debug && reallocatetape()
                 oldtapes = tapes
                 newtapelen = ceil(Int64, tapelen * 1.4)

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -276,7 +276,11 @@ function file(source,
     ncols = length(names)
     # might as well round up to the next largest pagesize, since mmap aligns to it anyway
     tapelen = roundup(trunc(Int64, rowsguess), Mmap.PAGESIZE)
-    tapes = Vector{UInt64}[Mmap.mmap(Vector{UInt64}, tapelen) for i = 1:ncols]
+    if use_mmap
+        tapes = Vector{UInt64}[Mmap.mmap(Vector{UInt64}, tapelen) for i = 1:ncols]
+    else
+        tapes = Vector{UInt64}[Vector{UInt64}(undef, tapelen) for i = 1:ncols]
+    end
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0
     refs = Vector{Dict{String, UInt64}}(undef, ncols)
     lastrefs = zeros(UInt64, ncols)

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -274,13 +274,8 @@ function file(source,
         # 16 bits for field length (allows for maximum field size of 65K)
     # the 2nd UInt64 is used for storing the raw bits of a parsed, typed value: Int64, Float64, Date, DateTime, Bool, or categorical/pooled UInt32 ref
     ncols = length(names)
-    # might as well round up to the next largest pagesize, since mmap aligns to it anyway
-    tapelen = roundup(trunc(Int64, rowsguess), Mmap.PAGESIZE)
-    if use_mmap
-        tapes = Vector{UInt64}[Mmap.mmap(Vector{UInt64}, tapelen) for i = 1:ncols]
-    else
-        tapes = Vector{UInt64}[Vector{UInt64}(undef, tapelen) for i = 1:ncols]
-    end
+    tapelen = rowsguess
+    tapes = Vector{UInt64}[Mmap.mmap(Vector{UInt64}, tapelen) for i = 1:ncols]
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0
     refs = Vector{Dict{String, UInt64}}(undef, ncols)
     lastrefs = zeros(UInt64, ncols)

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -274,7 +274,7 @@ function file(source,
         # 16 bits for field length (allows for maximum field size of 65K)
     # the 2nd UInt64 is used for storing the raw bits of a parsed, typed value: Int64, Float64, Date, DateTime, Bool, or categorical/pooled UInt32 ref
     ncols = length(names)
-    tapelen = rowsguess
+    tapelen = rowsguess * 2
     tapes = Vector{UInt64}[Mmap.mmap(Vector{UInt64}, tapelen) for i = 1:ncols]
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0
     refs = Vector{Dict{String, UInt64}}(undef, ncols)

--- a/src/filedetection.jl
+++ b/src/filedetection.jl
@@ -41,7 +41,7 @@ function datalayout_transpose(header, buf, pos, len, options, datarow, normalize
         columnnames = [columnname(buf, vpos, vlen, code, options, 1)]
         pos += tlen
         row, pos = skiptofield!(buf, pos, len, options, header+1, datarow)
-        columnpositions = [pos]
+        columnpositions = Int64[pos]
         datapos = pos
         rows, pos = countfields(buf, pos, len, options)
         
@@ -60,20 +60,22 @@ function datalayout_transpose(header, buf, pos, len, options, datarow, normalize
         end
     elseif isa(header, AbstractRange)
         # column names span several columns
+        columnpositions = Int64[]
+        columnnames = String[]
         throw(ArgumentError("not implemented for transposed csv files"))
     elseif pos > len
         # emtpy file, use column names if provided
         datapos = pos
-        columnpositions = Int[]
-        columnnames = header isa Vector && !isempty(header) ? header : []
+        columnpositions = Int64[]
+        columnnames = header isa Vector && !isempty(header) ? String[string(x) for x in header] : []
         rows = 0
     else
         # column names provided explicitly or should be generated, they don't exist in data
         # skip to datarow
         row, pos = skiptofield!(buf, pos, len, options, 1, datarow)
         # io now at start of 1st data cell
-        columnnames = [isa(header, Integer) || isempty(header) ? "Column1" : header[1]]
-        columnpositions = [pos]
+        columnnames = [isa(header, Integer) || isempty(header) ? "Column1" : string(header[1])]
+        columnpositions = Int64[pos]
         datapos = pos
         rows, pos = countfields(buf, pos, len, options)
         # we're now done w/ column 1, if EOF we're done, otherwise, parse column 2's column name
@@ -82,12 +84,12 @@ function datalayout_transpose(header, buf, pos, len, options, datarow, normalize
             # skip to datarow column
             row, pos = skiptofield!(buf, pos, len, options, 1, datarow)
             cols += 1
-            push!(columnnames, isa(header, Integer) || isempty(header) ? "Column$cols" : header[cols])
+            push!(columnnames, isa(header, Integer) || isempty(header) ? "Column$cols" : string(header[cols]))
             push!(columnpositions, pos)
             pos = readline!(buf, pos, len, options)
         end
     end
-    return rows, makeunique(map(x->normalizenames ? normalizename(x) : Symbol(x), columnnames)), columnpositions
+    return rows, makeunique(map(x->normalizenames ? normalizename(x) : Symbol(x), columnnames))::Vector{Symbol}, columnpositions
 end
 
 function datalayout(header::Integer, buf, pos, len, options, datarow, normalizenames, cmt)
@@ -107,7 +109,7 @@ function datalayout(header::Integer, buf, pos, len, options, datarow, normalizen
         end
         datapos = pos
     end
-    return columnnames, datapos
+    return columnnames, datapos::Int64
 end
 
 function datalayout(header::AbstractVector{<:Integer}, buf, pos, len, options, datarow, normalizenames, cmt)

--- a/src/filedetection.jl
+++ b/src/filedetection.jl
@@ -97,7 +97,7 @@ function datalayout(header::Integer, buf, pos, len, options, datarow, normalizen
     if header <= 0
         # no header row in dataset; skip to data to figure out # of columns
         pos = skipto!(buf, pos, len, options, 1, datarow)
-        datapos = pos
+        datapos = Int64(pos)
         fields, pos = readsplitline(buf, pos, len, options, cmt)
         columnnames = [Symbol(:Column, i) for i = eachindex(fields)]
     else
@@ -107,7 +107,7 @@ function datalayout(header::Integer, buf, pos, len, options, datarow, normalizen
         if datarow != header+1
             pos = skipto!(buf, pos, len, options, header+1, datarow)
         end
-        datapos = pos
+        datapos = Int64(pos)
     end
     return columnnames, datapos::Int64
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -5,9 +5,8 @@ Tables.columns(f::File) = f
 Base.propertynames(f::File) = getnames(f)
 
 struct Column{T, P} <: AbstractVector{T}
-    f::File
+    file::File
     col::Int
-    r::StepRange{Int, Int}
 end
 
 _eltype(::Type{T}) where {T} = T
@@ -15,13 +14,14 @@ _eltype(::Type{PooledString}) = String
 _eltype(::Type{Union{PooledString, Missing}}) = Union{String, Missing}
 
 function Column(f::File, i::Int)
-    T = gettypes(f)[i]
-    r = range(2 + ((i - 1) * 2), step=getcols(f) * 2, length=getrows(f))
-    return Column{_eltype(T), T}(f, i, r)
+    @inbounds T = gettypes(f)[i]
+    return Column{_eltype(T), T}(f, i)
 end
 
-Base.size(c::Column) = (length(c.r),)
+Base.size(c::Column) = (getrows(c.file),)
 Base.IndexStyle(::Type{<:Column}) = Base.IndexLinear()
+metaind(x) = 2 * x - 1
+valind(x) = 2 * x
 
 function Base.copy(c::Column{T}) where {T}
     len = length(c)
@@ -43,30 +43,31 @@ end
 
 function Base.copy(c::Column{T, S}) where {T <: Union{String, Union{String, Missing}}, S <: Union{PooledString, Union{PooledString, Missing}}}
     len = length(c)
-    catg = getcategorical(c.f)
+    catg = getcategorical(c.file)
+    tape = gettape(c.file, c.col)
     if S === PooledString
         refs = Dict{String, UInt32}()
-        foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.f)[c.col]))
+        foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.file, c.col)))
         values = Vector{UInt32}(undef, len)
         @simd for i = 1:len
-            @inbounds values[i] = ref(gettape(c.f)[c.r[i]])
+            @inbounds values[i] = ref(tape[valind(i)])
         end
     else
         if catg
             refs = Dict{String, UInt32}()
-            foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.f)[c.col]))
+            foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.file, c.col)))
             missingref = UInt32(0)
             values = Vector{UInt32}(undef, len)
         else
             refs = Dict{Union{String, Missing}, UInt32}()
-            foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.f)[c.col]))
+            foreach(x->setindex!(refs, UInt32(x[1]), x[2]), enumerate(getrefs(c.file, c.col)))
             missingref = UInt32(length(refs) + 1)
             refs[missing] = missingref
             values = Vector{UInt32}(undef, len)
         end
         @simd for i = 1:len
-            @inbounds offlen = gettape(c.f)[c.r[i] - 1]
-            @inbounds values[i] = ifelse(missingvalue(offlen), missingref, ref(gettape(c.f)[c.r[i]]))
+            @inbounds offlen = tape[metaind(i)]
+            @inbounds values[i] = ifelse(missingvalue(offlen), missingref, ref(tape[valind(i)]))
         end
     end
     if catg
@@ -92,65 +93,65 @@ end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{T}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
-    @inbounds x = reinterp_func(T)(gettape(c.f)[c.r[row]])
+    @inbounds x = reinterp_func(T)(gettape(c.file, c.col)[valind(row)])
     return x
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{Union{T, Missing}}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
-    @inbounds x = ifelse(missingvalue(offlen), missing, reinterp_func(T)(gettape(c.f)[c.r[row]]))
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
+    @inbounds x = ifelse(missingvalue(offlen), missing, reinterp_func(T)(gettape(c.file, c.col)[valind(row)]))
     return x
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{Float64}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
-    @inbounds v = gettape(c.f)[c.r[row]]
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
+    @inbounds v = gettape(c.file, c.col)[valind(row)]
     @inbounds x = ifelse(intvalue(offlen), Float64(int64(v)), float64(v))
     return x
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{Union{Float64, Missing}}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
-    @inbounds v = gettape(c.f)[c.r[row]]
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
+    @inbounds v = gettape(c.file, c.col)[valind(row)]
     @inbounds x = ifelse(missingvalue(offlen), missing, ifelse(intvalue(offlen), Float64(int64(v)), float64(v)))
     return x
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{String, PooledString}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds x = getrefs(c.f)[c.col][gettape(c.f)[c.r[row]]]
+    @inbounds x = getrefs(c.file, c.col)[gettape(c.file, c.col)[valind(row)]]
     return x
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{Union{String, Missing}, Union{PooledString, Missing}}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
     if missingvalue(offlen)
         return missing
     else
-        @inbounds x = getrefs(c.f)[c.col][gettape(c.f)[c.r[row]]]
+        @inbounds x = getrefs(c.file, c.col)[gettape(c.file, c.col)[valind(row)]]
         return x
     end
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{String}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
-    s = PointerString(pointer(getbuf(c.f), getpos(offlen)), getlen(offlen))
-    return escapedvalue(offlen) ? unescape(s, gete(c.f)) : String(s)
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
+    s = PointerString(pointer(getbuf(c.file), getpos(offlen)), getlen(offlen))
+    return escapedvalue(offlen) ? unescape(s, gete(c.file)) : String(s)
 end
 
 @inline Base.@propagate_inbounds function Base.getindex(c::Column{Union{String, Missing}}, row::Int)
     @boundscheck checkbounds(c, row)
-    @inbounds offlen = gettape(c.f)[c.r[row] - 1]
+    @inbounds offlen = gettape(c.file, c.col)[metaind(row)]
     if missingvalue(offlen)
         return missing
     else
-        s = PointerString(pointer(getbuf(c.f), getpos(offlen)), getlen(offlen))
-        return escapedvalue(offlen) ? unescape(s, gete(c.f)) : String(s)
+        s = PointerString(pointer(getbuf(c.file), getpos(offlen)), getlen(offlen))
+        return escapedvalue(offlen) ? unescape(s, gete(c.file)) : String(s)
     end
 end
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -18,7 +18,7 @@ function Column(f::File, i::Int)
     return Column{_eltype(T), T}(f, i)
 end
 
-Base.size(c::Column) = (getrows(c.file),)
+Base.size(c::Column) = (Int(getrows(c.file)),)
 Base.IndexStyle(::Type{<:Column}) = Base.IndexLinear()
 metaind(x) = 2 * x - 1
 valind(x) = 2 * x

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,7 +118,7 @@ uint64(x::Bool) = UInt64(x)
 uint64(x::Union{Date, DateTime}) = uint64(Dates.value(x))
 uint64(x::UInt32) = UInt64(x)
 
-function consumeBOM!(source)
+@noinline function consumeBOM!(source)
     # BOM character detection
     startpos = pos = 1
     len = length(source)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,7 +172,7 @@ const RESERVED = Set(["local", "global", "export", "let",
     "module", "elseif", "end", "quote", "do"])
 
 normalizename(name::Symbol) = name
-function normalizename(name::String)
+function normalizename(name::String)::Symbol
     uname = strip(Unicode.normalize(name))
     id = Base.isidentifier(uname) ? uname : map(c->Base.is_id_char(c) ? c : '_', uname)
     cleansed = string((isempty(id) || !Base.is_id_start_char(id[1]) || id in RESERVED) ? "_" : "", id)
@@ -181,7 +181,7 @@ end
 
 function makeunique(names)
     set = Set(names)
-    length(set) == length(names) && return names
+    length(set) == length(names) && return Symbol[Symbol(x) for x in names]
     nms = Symbol[]
     for nm in names
         if nm in nms


### PR DESCRIPTION
This aims to speed up the use of `CSV.Column` (#417) while also making the memory pressure more optimized on windows (#424). 

I haven't actually tested this on windows yet, but here's a view of the performance differences vs. the original that @bkamins posted in #417.
```julia
julia> @btime sum($df.x5);
  13.991 ms (1 allocation: 16 bytes)

julia> @btime sum($df2.x5);
  4.007 ms (1 allocation: 16 bytes)

julia> @btime count(==("a"), $df.g);
  79.931 ms (2 allocations: 32 bytes)

julia> @btime count(==("a"), $df2.g);
  69.326 ms (2 allocations: 32 bytes)

julia> @btime $df.x1-$df.x6;
  38.803 ms (2 allocations: 76.29 MiB)

julia> @btime $df2.x1-$df2.x6;
  22.243 ms (2 allocations: 76.29 MiB)
```