### PR TITLE
Fix an issue where a column's type was manually specified as pooled, …

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -286,12 +286,16 @@ function file(source,
         typecodes[i] &= ~USER
     end
     finaltypes = Type[TYPECODES[T] for T in typecodes]
-    debug && println("types after parsing: $finaltypes")
+    debug && println("types after parsing: $finaltypes, pool = $pool")
     finalrefs = Vector{Vector{String}}(undef, ncols)
     if pool > 0.0
         for i = 1:ncols
             if isassigned(refs, i)
                 finalrefs[i] = map(x->x[1], sort!(collect(refs[i]), by=x->x[2]))
+            elseif typecodes[i] == POOL || typecodes[i] == (POOL | MISSING)
+                # case where user manually specified types, but no rows were parsed
+                # so the refs never got initialized; initialize them here to empty
+                finalrefs[i] = Vector{String}[]
             end
         end
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -307,4 +307,11 @@ row = first(f)
 row = iterate(f, 2)[1]
 @test row.int_float === 3.14
 
+# reported by oxinabox on slack; issue w/ manually specified pool column type and 0 rows
+df = CSV.read(IOBuffer("x\n"), types=[CSV.PooledString], copycols=true)
+@test size(df) == (0, 1)
+
+df = CSV.read(IOBuffer("x\n"), types=[Union{CSV.PooledString, Missing}], copycols=true)
+@test size(df) == (0, 1)
+
 end

--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -550,7 +550,7 @@ testfiles = [
         (1079, 39),
         NamedTuple{(:SampleID, :Mother_Child, :SubjectID, :MaternalID, :TimePoint, :Fecal_EtOH, :CollectionRep, :DOC, :RAInitials_DOC, :DOF, :RAInitials_DOF, :Date_Brought_In, :RAInitials_Brought, :Date_Shipped, :RAInitials_Shipped, :Date_Aliquoted, :Number_Replicates, :RAInitials_Aliquot, :StorageBox, :DOE, :Extract_number, :AliquotRep, :DNABox, :KitUsed, :RAInitials_Extract, :DNAConc, :DOM, :Mgx_processed, :Mgx_batch, :DO16S, :_16S_processed, :_16S_batch, :_16S_plate, :Notes, :Discrepancies, :Batch_1_Mapping, :Mgx_batch_Mapping, :_16S_batch_Mapping, :Mother_Child_Dyads), Tuple{String, String, Int64, String, Int64, String, Int64, Dates.Date, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, Float64}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, String}, Union{Missing, Date}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, String}, Union{Missing, Int64}}},
         nothing
-    )
+    ),
 ];
 
 for test in testfiles


### PR DESCRIPTION
…but no rows were parsed, so the pool refs never got initialized

reported by @oxinabox on slack