### PR TITLE
Add a CSV.detect method that operates on a single string. This can be…

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,4 +184,17 @@ end
 
 end
 
+@testset "CSV.detect" begin
+
+@test CSV.detect("") == ""
+@test CSV.detect("1") == 1
+@test CSV.detect("1.1") == 1.1
+@test CSV.detect("2015-01-01") == Date(2015)
+@test CSV.detect("2015-01-01T03:04:05") == DateTime(2015, 1, 1, 3, 4, 5)
+@test CSV.detect("true") === true
+@test CSV.detect("false") === false
+@test CSV.detect("abc") === "abc"
+
+end
+
 end


### PR DESCRIPTION
… useful when using CSV.Rows, or if you have a weird scenario where your column is parsed as a String, but you might want to try to convert them to a value anyway. Closes #462