### PR TITLE
Fix parsing for date/times with custom dateformat

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -472,14 +472,17 @@ function detect(tape, tapeidx, buf, pos, len, options, row, col, typemap, pool, 
         catch e
         end
     else
-        # use user-provided dateformat
-        DT = timetype(options.dateformat)
-        dt, code, vpos, vlen, tlen = Parsers.xparse(DT, buf, pos, len, options)
-        if Parsers.ok(code)
-            setposlen!(tape, tapeidx, code, vpos, vlen)
-            @inbounds tape[tapeidx + 1] = uint64(dt)
-            @inbounds typecodes[col] = DT == Date ? (T == MISSINGTYPE ? (DATE | MISSING) : DATE) : DT == DateTime ? (T == MISSINGTYPE ? (DATETIME | MISSING) : DATETIME) : (T == MISSINGTYPE ? (TIME | MISSING) : TIME)
-            @goto done
+        try
+            # use user-provided dateformat
+            DT = timetype(options.dateformat)
+            dt, code, vpos, vlen, tlen = Parsers.xparse(DT, buf, pos, len, options)
+            if Parsers.ok(code)
+                setposlen!(tape, tapeidx, code, vpos, vlen)
+                @inbounds tape[tapeidx + 1] = uint64(dt)
+                @inbounds typecodes[col] = DT == Date ? (T == MISSINGTYPE ? (DATE | MISSING) : DATE) : DT == DateTime ? (T == MISSINGTYPE ? (DATETIME | MISSING) : DATETIME) : (T == MISSINGTYPE ? (TIME | MISSING) : TIME)
+                @goto done
+            end
+        catch e
         end
     end
     bool, code, vpos, vlen, tlen = Parsers.xparse(Bool, buf, pos, len, options)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -292,11 +292,14 @@ function detect(str::String; options=Parsers.OPTIONS)
         catch e
         end
     else
-        # use user-provided dateformat
-        DT = timetype(options.dateformat)
-        dt, code, vpos, vlen, tlen = Parsers.xparse(DT, buf, pos, len, options)
-        if Parsers.ok(code) && vlen == len
-            return dt
+        try
+            # use user-provided dateformat
+            DT = timetype(options.dateformat)
+            dt, code, vpos, vlen, tlen = Parsers.xparse(DT, buf, pos, len, options)
+            if Parsers.ok(code) && vlen == len
+                return dt
+            end
+        catch e
         end
     end
     bool, code, vpos, vlen, tlen = Parsers.xparse(Bool, buf, pos, len, options)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -337,4 +337,7 @@ f = CSV.File(IOBuffer("x\n1\n2\n3\n#4"), comment="#")
 df = CSV.read(IOBuffer("a,b,c\n1,2,3\n\n"), ignoreemptylines=true)
 @test size(df) == (1, 3)
 
+df = CSV.read(IOBuffer("zip\n11111-1111\n"), dateformat = "y-m-dTH:M:S.s")
+@test size(df) == (1, 1)
+
 end


### PR DESCRIPTION
Without the try / catch blocks, `detect()` fails when trying to parse something
similar to a date, but not a valid date (e.g., a US 5 + 4 zip code).

Adding the try / catch simply makes this test behave identically to the test
when not using a custom date format.

I've also added a test to `basics.jl` for this behaviour.