### PR TITLE
Allow DataFrames.jl version 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 CategoricalArrays = "0.5"
-DataFrames = "0.18"
+DataFrames = "0.18,0.19"
 Parsers = "0.3"
 PooledArrays = "0.5"
 Tables = "0.1,0.2"


### PR DESCRIPTION
Fixes #471.
@quinnj - I assume you prefer to keep allowed versions explicit. Right?
Otherwise we could write `">= 0.18" to avoid having making a release each time we change version of DataFrames.jl.