### PR TITLE
Allow CategoricalArrays v0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
-CategoricalArrays = "0.5"
+CategoricalArrays = "0.5,0.6"
 DataFrames = "0.18,0.19"
 Parsers = "0.3"
 PooledArrays = "0.5"


### PR DESCRIPTION
To avoid seeing the `Missings.T` deprecation warning from Missings.jl v0.4.2 when CSV.jl is present in the project