### PR TITLE
Make CSV.File subtype AbstractVector and cleanup iteration

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -37,7 +37,31 @@ _eltype(::Type{Union{PooledString, Missing}}) = Union{String, Missing}
 Base.size(c::Column) = (c.len,)
 Base.IndexStyle(::Type{<:Column}) = Base.IndexLinear()
 
-struct File
+struct Row{threaded}
+    names::Vector{Symbol}
+    columns::Vector{AbstractVector}
+    lookup::Dict{Symbol, AbstractVector}
+    row::Int64
+    array_index::Int64
+    array_i::Int64
+end
+
+getnames(r::Row) = getfield(r, :names)
+getcolumn(r::Row, col::Int) = getfield(r, :columns)[col]
+getcolumn(r::Row, col::Symbol) = getfield(r, :lookup)[col]
+getrow(r::Row) = getfield(r, :row)
+getarrayindex(r::Row) = getfield(r, :array_index)
+getarrayi(r::Row) = getfield(r, :array_i)
+
+Base.propertynames(r::Row) = getnames(r)
+
+function Base.show(io::IO, r::Row)
+    print(io, "CSV.Row($(getrow(r))): ")
+    names = getnames(r)
+    show(IOContext(io, :compact => true), NamedTuple{Tuple(names)}(Tuple(getproperty(r, nm) for nm in names)))
+end
+
+struct File{threaded} <: AbstractVector{Row}
     name::String
     names::Vector{Symbol}
     types::Vector{Type}
@@ -52,6 +76,8 @@ getnames(f::File) = getfield(f, :names)
 gettypes(f::File) = getfield(f, :types)
 getrows(f::File) = getfield(f, :rows)
 getcols(f::File) = getfield(f, :cols)
+getcolumns(f::File) = getfield(f, :columns)
+getlookup(f::File) = getfield(f, :lookup)
 getcolumn(f::File, col::Int) = getfield(f, :columns)[col]
 getcolumn(f::File, col::Symbol) = getfield(f, :lookup)[col]
 
@@ -60,6 +86,11 @@ function Base.show(io::IO, f::File)
     println(io, "Size: $(getrows(f)) x $(getcols(f))")
     show(io, Tables.schema(f))
 end
+
+Base.IndexStyle(::Type{File}) = Base.IndexLinear()
+Base.eltype(f::File{threaded}) where {threaded} = Row{threaded}
+Base.size(f::File) = (getrows(f),)
+Base.Vector{AbstractVector}(f::File) = getcolumns(f)
 
 const EMPTY_POSITIONS = Int64[]
 const EMPTY_TYPEMAP = Dict{TypeCode, TypeCode}()
@@ -440,7 +471,7 @@ function file(source,
         columns = AbstractVector[Column{_eltype(finaltypes[i]), finaltypes[i]}(tapes[i], rows, eq, categorical, finalrefs[i], buf, finaltypes[i] >: Int64 ? uint64(intsentinels[i]) : sentinelvalue(Base.nonmissingtype(finaltypes[i]))) for i = 1:ncols]
     end
     lookup = Dict(k => v for (k, v) in zip(names, columns))
-    return File(getname(source), names, finaltypes, finalrows, ncols, columns, lookup)
+    return File{something(threaded, false)}(getname(source), names, finaltypes, finalrows, ncols, columns, lookup)
 end
 
 function multithreadparse(typecodes, buf, datapos, len, options, rowsguess, pool, ncols, ignoreemptylines, typemap, limit, cmt, debug)
@@ -1037,6 +1068,8 @@ Parses a delimited file into a `DataFrame`. `copycols` determines whether a copy
 `CSV.read` supports the same keyword arguments as [`CSV.File`](@ref).
 """
 read(source; copycols::Bool=false, kwargs...) = DataFrame(CSV.File(source; kwargs...), copycols=copycols)
+
+DataFrames.DataFrame(f::CSV.File; copycols::Bool=false) = DataFrame(getcolumns(f), getnames(f); copycols=copycols)
 
 function __init__()
     # Threads.resize_nthreads!(VALUE_BUFFERS)

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -61,7 +61,7 @@ function Base.show(io::IO, r::Row)
     show(IOContext(io, :compact => true), NamedTuple{Tuple(names)}(Tuple(getproperty(r, nm) for nm in names)))
 end
 
-struct File{threaded} <: AbstractVector{Row}
+struct File{threaded} <: AbstractVector{Row{threaded}}
     name::String
     names::Vector{Symbol}
     types::Vector{Type}
@@ -90,7 +90,6 @@ end
 Base.IndexStyle(::Type{File}) = Base.IndexLinear()
 Base.eltype(f::File{threaded}) where {threaded} = Row{threaded}
 Base.size(f::File) = (getrows(f),)
-Base.Vector{AbstractVector}(f::File) = getcolumns(f)
 
 const EMPTY_POSITIONS = Int64[]
 const EMPTY_TYPEMAP = Dict{TypeCode, TypeCode}()

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -37,6 +37,8 @@ _eltype(::Type{Union{PooledString, Missing}}) = Union{String, Missing}
 Base.size(c::Column) = (c.len,)
 Base.IndexStyle(::Type{<:Column}) = Base.IndexLinear()
 
+# getindex definitions in tables.jl
+
 struct Row{threaded}
     names::Vector{Symbol}
     columns::Vector{AbstractVector}

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -2,12 +2,12 @@
 Tables.rowaccess(::Type{<:File}) = true
 Tables.rows(f::File) = f
 
-@inline Base.@propagate_inbounds function Base.getindex(f::File{false}, row::Int)
+Base.@propagate_inbounds function Base.getindex(f::File{false}, row::Int)
     @boundscheck checkbounds(f, row)
     return Row{false}(getnames(f), getcolumns(f), getlookup(f), row, 0, 0)
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(f::File{true}, row::Int)
+Base.@propagate_inbounds function Base.getindex(f::File{true}, row::Int)
     @boundscheck checkbounds(f, row)
     c = getcolumn(f, 1)
     i = row
@@ -73,6 +73,12 @@ end
     return x
 end
 
+@inline function Base.getindex(row::Row{false}, col::Symbol)
+    column = getcolumn(row, col)
+    @inbounds x = column[getrow(row)]
+    return x
+end
+
 @inline function Base.getproperty(row::Row{true}, col::Symbol)
     column = getcolumn(row, col)
     @inbounds x = column.args[getarrayindex(row)][getarrayi(row)]
@@ -80,6 +86,12 @@ end
 end
 
 @inline function Base.getindex(row::Row{true}, col::Int)
+    column = getcolumn(row, col)
+    @inbounds x = column.args[getarrayindex(row)][getarrayi(row)]
+    return x
+end
+
+@inline function Base.getindex(row::Row{true}, col::Symbol)
     column = getcolumn(row, col)
     @inbounds x = column.args[getarrayindex(row)][getarrayi(row)]
     return x

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -2,76 +2,85 @@
 Tables.rowaccess(::Type{<:File}) = true
 Tables.rows(f::File) = f
 
-struct Row{T}
-    file::File
-    row::T
+@inline Base.@propagate_inbounds function Base.getindex(f::File{false}, row::Int)
+    @boundscheck checkbounds(f, row)
+    return Row{false}(getnames(f), getcolumns(f), getlookup(f), row, 0, 0)
 end
 
-getfile(r::Row) = getfield(r, :file)
-getrow(r::Row) = getfield(r, :row)
-
-Base.propertynames(r::Row) = getnames(getfile(r))
-
-function Base.show(io::IO, r::Row)
-    println(io, "CSV.Row($(getrow(r))) of:")
-    show(io, getfile(r))
+@inline Base.@propagate_inbounds function Base.getindex(f::File{true}, row::Int)
+    @boundscheck checkbounds(f, row)
+    c = getcolumn(f, 1)
+    i = row
+    for (j, A) in enumerate(c.args)
+        n = length(A)
+        i <= n && return Row{true}(getnames(f), getcolumns(f), getlookup(f), row, j, i)
+        i -= n
+    end
+    return Row{true}(getnames(f), getcolumns(f), getlookup(f), row, 1, 1)
 end
 
-Base.eltype(f::File) = Row
-Base.length(f::File) = getrows(f)
+# non-threaded file
+@inline function Base.iterate(f::File{false}, st::Int=1)
+    st > length(f) && return nothing
+    return Row{false}(getnames(f), getcolumns(f), getlookup(f), st, 0, 0), st + 1
+end
 
-function Base.iterate(f::File)
+# threaded file
+mutable struct RowIterationState
+    row::Int64
+    array_index::Int64
+    array_i::Int64
+    array_len::Int64
+    array_lens::Vector{Int64}
+end
+
+@inline function Base.iterate(f::File{true})
     cols = getcols(f)
     (cols == 0 || getrows(f) == 0) && return nothing
     c = getcolumn(f, 1)
-    if typeof(c) <: LazyArrays.ApplyArray
-        return Row(f, (1, 1, 1, c.args)), (1, 2, 2, c.args)
-    else
-        return Row(f, 1), 2
-    end
+    array_lens = [length(x) for x in c.args]
+    st = RowIterationState(2, 1, 2, array_lens[1], array_lens)
+    return Row{true}(getnames(f), getcolumns(f), getlookup(f), 1, 1, 1), st
 end
 
-@inline function Base.iterate(f::File, st::Int)
-    st > length(f) && return nothing
-    return Row(f, st), st + 1
-end
-
-@inline function Base.iterate(f::File, st)
-    st[3] > length(f) && return nothing
-    if st[2] + 1 > length(st[4][st[1]])
-        st1 += 1
-        st2 = 1
+@inline function Base.iterate(f::File{true}, st)
+    row = st.row
+    array_index = st.array_index
+    array_i = st.array_i
+    row > length(f) && return nothing
+    if array_i + 1 > st.array_len
+        st.array_index += 1
+        st.array_i = 1
+        st.array_len = st.array_lens[min(end, st.array_index)]
     else
-        st1 = st[1]
-        st2 = st[2]
+        st.array_i += 1
     end
-    return Row(f, st), (st1, st2, st + 1, st[4])
+    st.row += 1
+    return Row{true}(getnames(f), getcolumns(f), getlookup(f), row, array_index, array_i), st
 end
 
 @noinline badcolumnerror(name) = throw(ArgumentError("`$name` is not a valid column name"))
 
-@inline function Base.getproperty(row::Row{Int}, name::Symbol)
-    column = getcolumn(getfile(row), name)
+@inline function Base.getproperty(row::Row{false}, col::Symbol)
+    column = getcolumn(row, col)
     @inbounds x = column[getrow(row)]
     return x
 end
 
-@inline function Base.getindex(row::Row{Int}, i::Int)
-    column = getcolumn(getfile(row), i)
+@inline function Base.getindex(row::Row{false}, col::Int)
+    column = getcolumn(row, col)
     @inbounds x = column[getrow(row)]
     return x
 end
 
-@inline function Base.getproperty(row::Row, name::Symbol)
-    column = getcolumn(getfile(row), name)
-    r = getrow(row)
-    @inbounds x = column.args[r[1]][r[2]]
+@inline function Base.getproperty(row::Row{true}, col::Symbol)
+    column = getcolumn(row, col)
+    @inbounds x = column.args[getarrayindex(row)][getarrayi(row)]
     return x
 end
 
-@inline function Base.getindex(row::Row, i::Int)
-    column = getcolumn(getfile(row), i)
-    r = getrow(row)
-    @inbounds x = column.args[r[1]][r[2]]
+@inline function Base.getindex(row::Row{true}, col::Int)
+    column = getcolumn(row, col)
+    @inbounds x = column.args[getarrayindex(row)][getarrayi(row)]
     return x
 end

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -69,31 +69,31 @@ function Base.copy(c::Column{T, S}) where {T <: Union{String, Union{String, Miss
     return A
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{Missing}, row::Int)
+Base.@propagate_inbounds function Base.getindex(c::Column{Missing}, row::Int)
     @boundscheck checkbounds(c, row)
     return missing
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{T, S}, row::Int) where {T, S}
+Base.@propagate_inbounds function Base.getindex(c::Column{T, S}, row::Int) where {T, S}
     @boundscheck checkbounds(c, row)
     @inbounds x = reinterp_func(T)(c.tape[row])
     return x
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{Union{T, Missing}, S}, row::Int) where {T, S}
+Base.@propagate_inbounds function Base.getindex(c::Column{Union{T, Missing}, S}, row::Int) where {T, S}
     @boundscheck checkbounds(c, row)
     @inbounds x = c.tape[row]
     return ifelse(x === c.sentinel, missing, reinterp_func(T)(x))
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{T, PooledString}, row::Int) where {T}
+Base.@propagate_inbounds function Base.getindex(c::Column{T, PooledString}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
     @inbounds x = c.tape[row]
     @inbounds str = c.refs[x]
     return str
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{T, Union{PooledString, Missing}}, row::Int) where {T}
+Base.@propagate_inbounds function Base.getindex(c::Column{T, Union{PooledString, Missing}}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
     @inbounds x = c.tape[row]
     if x == 0
@@ -104,14 +104,14 @@ end
     end
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{T, String}, row::Int) where {T}
+Base.@propagate_inbounds function Base.getindex(c::Column{T, String}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
     @inbounds offlen = c.tape[row]
     s = PointerString(pointer(c.buf, getpos(offlen)), getlen(offlen))
     return escapedvalue(offlen) ? unescape(s, c.e) : String(s)
 end
 
-@inline Base.@propagate_inbounds function Base.getindex(c::Column{T, Union{String, Missing}}, row::Int) where {T}
+Base.@propagate_inbounds function Base.getindex(c::Column{T, Union{String, Missing}}, row::Int) where {T}
     @boundscheck checkbounds(c, row)
     @inbounds offlen = c.tape[row]
     if missingvalue(offlen)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -299,7 +299,7 @@ f = CSV.File(IOBuffer("int,float,date,datetime,bool,null,str,catg,int_float\n1,3
 @test Tables.columnaccess(typeof(f))
 @test Tables.schema(f) == Tables.Schema([:int, :float, :date, :datetime, :bool, :null, :str, :catg, :int_float], [Int64, Float64, Date, DateTime, Bool, Missing, String, String, Float64])
 @test Tables.rows(f) === f
-@test eltype(f) == CSV.Row
+@test eltype(f) <: CSV.Row
 row = first(f)
 @test propertynames(row) == [:int, :float, :date, :datetime, :bool, :null, :str, :catg, :int_float]
 @test row.int == 1


### PR DESCRIPTION
I'd love to get feedback from @nalimilan, @bkamins, and @andyferris on this. Changes include:

* Adding a `threaded` type parameter to `CSV.File`; this is convenient for dispatching for non-threaded vs. threaded files, and avoids at least one additional dynamic dispatch while not adding a ton of overhead (i.e. a single boolean type parameter)
* Makes the subtyping `struct File{threaded} <: AbstractVector{Row{threaded}}` official
* Adds a `getindex` method on `CSV.File`

I will note that iterating and accessing row values on threaded files currently has a performance cost vs. non-threaded case due to the LazyArray tuple of columns not being fully encoded in the `CSV.File` object. That feels like drastically too high a cost (essentially encoding all columns/types in `CSV.File`). I feel like the threaded iteration perf cost is somewhat justified though, since 1) there's no way we're encoding the full column types in `CSV.File`, 2) we have `CSV.Rows` which provides a much more reasonable iteration flow for large, threaded files, and 3) you can pass `threaded=false` and get super fast iteration if you need. A bonus reason is we can always hope/count on compiler magic to make things better/faster.