### PR TITLE
Default to  `copycols=true` in `DataFrames` constructor

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -1070,7 +1070,7 @@ Parses a delimited file into a `DataFrame`. `copycols` determines whether a copy
 """
 read(source; copycols::Bool=false, kwargs...) = DataFrame(CSV.File(source; kwargs...), copycols=copycols)
 
-DataFrames.DataFrame(f::CSV.File; copycols::Bool=false) = DataFrame(getcolumns(f), getnames(f); copycols=copycols)
+DataFrames.DataFrame(f::CSV.File; copycols::Bool=true) = DataFrame(getcolumns(f), getnames(f); copycols=copycols)
 
 function __init__()
     # Threads.resize_nthreads!(VALUE_BUFFERS)


### PR DESCRIPTION
This is required for consistency with the generic `DataFrames` constructor.
Reverting this avoids introducing a breaking change, as `df = DataFrame(CSV.File(...)); append!(df, row)` used to work and has to keep working.