### PR TITLE
If a parsed column name is empty (i.e. zero length), then generate a …

### DIFF
--- a/src/detection.jl
+++ b/src/detection.jl
@@ -238,7 +238,7 @@ function readsplitline(buf, pos, len, options::Parsers.Options{ignorerepeated}) 
 end
 
 function columnname(buf, vpos, vlen, code, options, i)
-    if Parsers.sentinel(code)
+    if Parsers.sentinel(code) || vlen == 0
         return "Column$i"
     elseif Parsers.escapedstring(code)
         return unescape(PointerString(pointer(buf, vpos), vlen), options.e)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -378,4 +378,8 @@ df = CSV.read(IOBuffer("thistime\n10:00:00.0\n12:00:00.0"))
 @test typeof(df.thistime[1]) <: Dates.Time
 @test df.thistime[1] === Time(10)
 
+# 530
+df = CSV.read(IOBuffer(",column2\nNA,2\n2,3"), missingstrings=["NA"])
+@test names(df) == [:Column1, :column2]
+
 end


### PR DESCRIPTION
…column name. Fixes #530