### PR TITLE
Added treatnothingasmissing option

### DIFF
--- a/test/perf_write.jl
+++ b/test/perf_write.jl
@@ -1,0 +1,12 @@
+using DataFrames, CSV, BenchmarkTools
+
+function test(n)
+    df = DataFrame(x = rand(n), y = rand(n), z = rand(n))
+    @benchmark CSV.write("/tmp/tom.csv", $df)
+end
+
+for i in 4:7
+    rows = 10^i
+    println(rows, " rows: ", test(rows))
+end
+

--- a/test/write.jl
+++ b/test/write.jl
@@ -51,8 +51,8 @@ using CSV, Dates, WeakRefStrings, CategoricalArrays, Tables
     (col1=[1,nothing,3], col2=[nothing, nothing, nothing], col3=[7,8,9]) |> CSV.write(io; treatnothingasmissing=true, missingstring="NA")
     @test String(take!(io)) == "col1,col2,col3\n1,NA,7\nNA,NA,8\n3,NA,9\n"
 
-    (col1=[1,nothing,3], col2=[nothing, nothing, nothing], col3=[7,8,9]) |> CSV.write(io; treatnothingasmissing=false, missingstring="NA")
-    @test String(take!(io)) == "col1,col2,col3\n1,,7\n,,8\n3,,9\n"
+    @test_throws ErrorException (col1=[1,nothing,3], col2=[nothing, nothing, nothing], col3=[7,8,9]) |>
+        CSV.write(io; treatnothingasmissing=false, missingstring="NA")
 
     (col1=["hey, there, sailor", "this, also, has, commas", "this\n has\n newlines\n", "no quoting", "just a random \" quote character", ],) |> CSV.write(io; escapechar='\\')
     @test String(take!(io)) == "col1\n\"hey, there, sailor\"\n\"this, also, has, commas\"\n\"this\n has\n newlines\n\"\nno quoting\n\"just a random \\\" quote character\"\n"

--- a/test/write.jl
+++ b/test/write.jl
@@ -48,6 +48,12 @@ using CSV, Dates, WeakRefStrings, CategoricalArrays, Tables
     (col1=[1,missing,3], col2=[missing, missing, missing], col3=[7,8,9]) |> CSV.write(io; missingstring="NA")
     @test String(take!(io)) == "col1,col2,col3\n1,NA,7\nNA,NA,8\n3,NA,9\n"
 
+    (col1=[1,nothing,3], col2=[nothing, nothing, nothing], col3=[7,8,9]) |> CSV.write(io; treatnothingasmissing=true, missingstring="NA")
+    @test String(take!(io)) == "col1,col2,col3\n1,NA,7\nNA,NA,8\n3,NA,9\n"
+
+    (col1=[1,nothing,3], col2=[nothing, nothing, nothing], col3=[7,8,9]) |> CSV.write(io; treatnothingasmissing=false, missingstring="NA")
+    @test String(take!(io)) == "col1,col2,col3\n1,,7\n,,8\n3,,9\n"
+
     (col1=["hey, there, sailor", "this, also, has, commas", "this\n has\n newlines\n", "no quoting", "just a random \" quote character", ],) |> CSV.write(io; escapechar='\\')
     @test String(take!(io)) == "col1\n\"hey, there, sailor\"\n\"this, also, has, commas\"\n\"this\n has\n newlines\n\"\nno quoting\n\"just a random \\\" quote character\"\n"
 
@@ -90,7 +96,7 @@ using CSV, Dates, WeakRefStrings, CategoricalArrays, Tables
     rm(file)
 
     # unknown schema case
-    opts = CSV.Options(UInt8(','), UInt8('"'), UInt8('"'), UInt8('"'), UInt8('\n'), UInt8('.'), nothing, false, ())
+    opts = CSV.Options(UInt8(','), UInt8('"'), UInt8('"'), UInt8('"'), UInt8('\n'), UInt8('.'), nothing, false, (), false)
     io = IOBuffer()
     CSV.write(nothing, Tables.rows((col1=[1,2,3], col2=[4,5,6], col3=[7,8,9])), io, opts)
     @test String(take!(io)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"


### PR DESCRIPTION
Due to https://github.com/JuliaLang/julia/pull/32148, CSV now writes files with "nothing" in the CSV file.  This is arguably not the right behavior.  

Here's the MWE:
```
julia> CSV.write("/tmp/tom.csv", [(1,2,nothing)], writeheader = false); readlines("/tmp/tom.csv")
1-element Array{String,1}:
 "1,2,nothing"
```

From [Slack discussion](https://julialang.slack.com/archives/C674VR0HH/p1578678980221600), an idea is to allow `nothing` to be treated like `missing` so the user does not need to translate the data to `missing` before writing a CSV file, which is a huge convenient factor.  
This PR adds a new `treatnothingasmissing` option.  Behavior as follows:

1. When it is set to `true`, the writer will treat `nothing` like `missing`.  A positive effect is that we can now print `nothing` as `NA` if `missingstring` is also specified.  
2. When it is set to `false`, the writer will output an empty string for `nothing`, which should be a better default for sane people.