### PR TITLE
update description of CI specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The package is registered in the [`General`](https://github.com/JuliaRegistries/
 
 ## Project Status
 
-The package is tested against Julia `1.0`, `1.1` and nightly on Linux, OS X, and Windows.
+The package is tested against Julia `1.0`, current stable release, and nightly on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 


### PR DESCRIPTION
I proposed a generic text so that we do not have to update README.md as new stable releases of Julia are shipped (currently we test against 1.3 not 1.1).