### PR TITLE
Cell based transform on CSV.write

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -186,9 +186,9 @@ function writerow(buf, pos, len, io, sch, row, cols, opts)
         val === nothing && error(
             """
             A `nothing` value was found in column $col and it is not a printable value. 
-            There are several ways to handle this situation:\n
-            1) fix the data, perhaps replace `nothing` with `missing`, \n
-            2) use `transform` option with a funciton to replace `nothing` with whatever value (including `missing`), or\n
+            There are several ways to handle this situation:
+            1) fix the data, perhaps replace `nothing` with `missing`,
+            2) use `transform` option with a funciton to replace `nothing` with whatever value (including `missing`), or
             3) use `Tables.transform` option to transform specific columns
             """)
         posx = writecell(buf, pos[], len, io, val, opts)

--- a/test/perf_write.jl
+++ b/test/perf_write.jl
@@ -1,0 +1,26 @@
+using DataFrames, CSV, BenchmarkTools
+
+randnothing(pct_nothing) = let v = rand() 
+    v < pct_nothing ? nothing : v
+end
+
+randnothing(n, pct_nothing) = [randnothing(pct_nothing) for _ in 1:n]
+
+function test(n, pct_nothing)
+    df = DataFrame(x = randnothing(n, pct_nothing), y = randnothing(n, pct_nothing), z = randnothing(n, pct_nothing))
+    b1 = pct_nothing > 0 ? nothing : @benchmark CSV.write("/tmp/tom.csv", $df)
+    b2 = @benchmark CSV.write("/tmp/tom.csv", $df, transform = (col,val) -> something(val, missing))
+    return (default = b1, transform_to_missing = b2)
+end
+
+println("Performance test without any nothing values:")
+for i in 4:7
+    rows = 10^i
+    println(rows, " rows: ", test(rows, 0))
+end
+
+println("Performance test with some nothing values:")
+for i in 4:7
+    rows = 10^i
+    println(rows, " rows: ", test(rows, 0.1))
+end

--- a/test/perf_write.jl
+++ b/test/perf_write.jl
@@ -4,23 +4,34 @@ randnothing(pct_nothing) = let v = rand()
     v < pct_nothing ? nothing : v
 end
 
-randnothing(n, pct_nothing) = [randnothing(pct_nothing) for _ in 1:n]
+randnothing(n, pct) = [randnothing(pct) for _ in 1:n]
 
-function test(n, pct_nothing)
-    df = DataFrame(x = randnothing(n, pct_nothing), y = randnothing(n, pct_nothing), z = randnothing(n, pct_nothing))
-    b1 = pct_nothing > 0 ? nothing : @benchmark CSV.write("/tmp/tom.csv", $df)
-    b2 = @benchmark CSV.write("/tmp/tom.csv", $df, transform = (col,val) -> something(val, missing))
-    return (default = b1, transform_to_missing = b2)
+df1(n) = DataFrame(x = rand(n), y = rand(n), z = rand(n))
+
+df2(n, pct = 0.1) = 
+    DataFrame(x = randnothing(n, pct), y = randnothing(n, pct), z = randnothing(n, pct))
+
+test1(df) = @benchmark CSV.write("/tmp/tom.csv", $df)
+
+test2(df) = @benchmark CSV.write("/tmp/tom.csv", $df, transform = (col,val) -> something(val, missing))
+
+function test(msg, f, df)
+    println(msg)
+    for i in 4:7
+        rows = 10^i
+        println(rows, " rows: ", f(df(rows)))
+    end
 end
 
-println("Performance test without any nothing values:")
-for i in 4:7
-    rows = 10^i
-    println(rows, " rows: ", test(rows, 0))
-end
+length(ARGS) > 0 || (println("Usage: julia perf_write.jl [master|new]"); exit(1))
+command = ARGS[1]
 
-println("Performance test with some nothing values:")
-for i in 4:7
-    rows = 10^i
-    println(rows, " rows: ", test(rows, 0.1))
+if command == "master"
+    test("Testing without nothing values", test1, df1)
+elseif command == "new"
+    test("Testing without nothing values (default transform)", test1, df1)
+    test("Testing without nothing values (to-missing transform)", test2, df1)
+    test("Testing with nothing values (to-missing transform)", test2, df2)
+else 
+    error("Unknown command: $command")
 end

--- a/test/write.jl
+++ b/test/write.jl
@@ -48,6 +48,11 @@ using CSV, Dates, WeakRefStrings, CategoricalArrays, Tables
     (col1=[1,missing,3], col2=[missing, missing, missing], col3=[7,8,9]) |> CSV.write(io; missingstring="NA")
     @test String(take!(io)) == "col1,col2,col3\n1,NA,7\nNA,NA,8\n3,NA,9\n"
 
+    @test_throws ErrorException (col1=[1,nothing,3], col2=[nothing, missing, missing], col3=[7,8,9]) |> CSV.write(io)
+
+    (col1=[1,nothing,3], col2=[nothing, missing, missing], col3=[7,8,9]) |> CSV.write(io; transform = (col, val) -> something(val, missing), missingstring="NA")
+    @test String(take!(io)) == "col1,col2,col3\n1,NA,7\nNA,NA,8\n3,NA,9\n"
+
     (col1=["hey, there, sailor", "this, also, has, commas", "this\n has\n newlines\n", "no quoting", "just a random \" quote character", ],) |> CSV.write(io; escapechar='\\')
     @test String(take!(io)) == "col1\n\"hey, there, sailor\"\n\"this, also, has, commas\"\n\"this\n has\n newlines\n\"\nno quoting\n\"just a random \\\" quote character\"\n"
 
@@ -90,7 +95,7 @@ using CSV, Dates, WeakRefStrings, CategoricalArrays, Tables
     rm(file)
 
     # unknown schema case
-    opts = CSV.Options(UInt8(','), UInt8('"'), UInt8('"'), UInt8('"'), UInt8('\n'), UInt8('.'), nothing, false, ())
+    opts = CSV.Options(UInt8(','), UInt8('"'), UInt8('"'), UInt8('"'), UInt8('\n'), UInt8('.'), nothing, false, (), (col,val)->val)
     io = IOBuffer()
     CSV.write(nothing, Tables.rows((col1=[1,2,3], col2=[4,5,6], col3=[7,8,9])), io, opts)
     @test String(take!(io)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"


### PR DESCRIPTION
This is an orthogonal PR for the same purpose as described in #562.  For background information, please refer to that issue.

### Changes

1. Introduce a new `transform` option for `CSV.write`, which accepts two arguments - column index and value.  This transform function is applied to every cell before writing to the output stream.  The default is `(col, val) -> val`, pretty much an identity function.

2. Throw an error when `nothing` is encountered during `CSV.write`.  The error string looks like this:
```
julia> (c1=[1],c2=[nothing],c3=[2]) |> CSV.write(stdout)
ERROR: A `nothing` value was found in column 2 and it is not a printable value. 
There are several ways to handle this situation:
1) fix the data, perhaps replace `nothing` with `missing`,
2) use `transform` option with a funciton to replace `nothing` with whatever value (including `missing`), or
3) use `Tables.transform` option to transform specific columns
```

### Performance

Performance results indicate that there is **no material degradation** with either the default transform function or a transform function that converts `nothing` to `missing`. The test harness is in `test/perf_write.jl`.

Master:
```
$ git status
HEAD detached at v0.5.22

$ julia --project=. /tmp/perf_write.jl master
Testing without nothing values
10000 rows: Trial(2.778 ms)
100000 rows: Trial(42.258 ms)
1000000 rows: Trial(429.475 ms)
10000000 rows: Trial(5.877 s)
```

This PR:
```
$ julia --project=. /tmp/perf_write.jl new
Testing without nothing values (default transform)
10000 rows: Trial(2.908 ms)
100000 rows: Trial(40.570 ms)
1000000 rows: Trial(415.337 ms)
10000000 rows: Trial(5.623 s)
Testing without nothing values (to-missing transform)
10000 rows: Trial(2.901 ms)
100000 rows: Trial(41.631 ms)
1000000 rows: Trial(421.154 ms)
10000000 rows: Trial(5.829 s)
Testing with nothing values (to-missing transform)
10000 rows: Trial(2.779 ms)
100000 rows: Trial(38.552 ms)
1000000 rows: Trial(380.628 ms)
10000000 rows: Trial(6.017 s)
```