### PR TITLE
Fix #566. The issue here was our footerskip logic reversed the input …

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -361,7 +361,7 @@ function file(source,
     if footerskip > 0 && len > 0
         lastbyte = buf[end]
         endpos = (lastbyte == UInt8('\r') || lastbyte == UInt8('\n')) +
-            lastbyte == UInt8('\n') && buf[end - 1] == UInt8('\r')
+            (lastbyte == UInt8('\n') && buf[end - 1] == UInt8('\r'))
         revlen = skiptorow(ReversedBuf(buf), 1 + endpos, len, oq, eq, cq, 0, footerskip) - 2
         len -= revlen
         debug && println("adjusted for footerskip, len = $(len + revlen - 1) => $len")

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -359,7 +359,10 @@ function file(source,
     cmt = comment === nothing ? nothing : (pointer(comment), sizeof(comment))
 
     if footerskip > 0 && len > 0
-        revlen = skiptorow(ReversedBuf(buf), 1 + (buf[end] == UInt('\n') || buf[end] == UInt8('\r')), len, oq, eq, cq, 0, footerskip) - 2
+        lastbyte = buf[end]
+        endpos = (lastbyte == UInt8('\r') || lastbyte == UInt8('\n')) +
+            lastbyte == UInt8('\n') && buf[end - 1] == UInt8('\r')
+        revlen = skiptorow(ReversedBuf(buf), 1 + endpos, len, oq, eq, cq, 0, footerskip) - 2
         len -= revlen
         debug && println("adjusted for footerskip, len = $(len + revlen - 1) => $len")
     end

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -209,6 +209,7 @@ function skiptorow(buf, pos, len, oq, eq, cq, cur, dest)
                     end
                 end
             elseif b == UInt8('\n')
+                typeof(buf) == ReversedBuf && pos <= len && buf[pos] == UInt8('\r') && (pos += 1)
                 break
             elseif b == UInt8('\r')
                 pos <= len && buf[pos] == UInt8('\n') && (pos += 1)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -386,4 +386,9 @@ df = CSV.read(IOBuffer(",column2\nNA,2\n2,3"), missingstrings=["NA"])
 df = CSV.read(IOBuffer("x\n01:02:03\n\n04:05:06\n"), delim=',')
 @test isequal(df.x, [Dates.Time(1,2,3), missing, Dates.Time(4,5,6)])
 
+# 566
+f = CSV.File(IOBuffer("x\r\n1\r\n2\r\n3\r\n4\r\n5\r\n"), footerskip=3)
+@test length(f) == 3
+@test f[1][1] == 1
+
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -388,7 +388,7 @@ df = CSV.read(IOBuffer("x\n01:02:03\n\n04:05:06\n"), delim=',')
 
 # 566
 f = CSV.File(IOBuffer("x\r\n1\r\n2\r\n3\r\n4\r\n5\r\n"), footerskip=3)
-@test length(f) == 3
+@test length(f) == 2
 @test f[1][1] == 1
 
 end


### PR DESCRIPTION
…buffer and checked for newlines, but forgot to account for the CRLF on windows in reversed order