### PR TITLE
Fix #578: multithreaded parsing on really wide files

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -391,4 +391,9 @@ f = CSV.File(IOBuffer("x\r\n1\r\n2\r\n3\r\n4\r\n5\r\n"), footerskip=3)
 @test length(f) == 2
 @test f[1][1] == 1
 
+# 578
+df = CSV.read(IOBuffer("h1234567890123456\t"^2262 * "lasthdr\r\n" *"dummy dummy dummy\r\n"* ("1.23\t"^2262 * "2.46\r\n")^10), datarow=3)
+@test size(df) == (10, 2263)
+@test all(x -> eltype(x) == Float64, eachcol(df))
+
 end


### PR DESCRIPTION
The issue here is that when we chunked up the file to determine the
starting position that each thread can parse, we forgot to account for
any skipped rows, which led to the unfortunate scenario in #578 where
the 1st thread technically started on the correct row 3 of the data, but
the 2nd thread was actually starting parsing at a byte position _before_
row 3.

Another issue I noticed while debugging was the "file" was estimated to
have 12 rows, which is pretty accurate, but then when we chunked up the
file for multithreaded parsing, each thread only expected 1 row
(essentially it did `div(12, 8)`), which led to two of the threads
having to re-allocate while parsing to fit the 2 rows unaccounted for.
By switching the calculating to `cld(12, 8)`, each thread plans on 2
rows and we avoid any re-allocating. For very wide files like in #578,
this is a tad inefficient because each extra row is really wide, but in
the general case, this should avoid re-allocating a little more often.