### PR TITLE
Fix multithreaded column type promotions

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -96,8 +96,7 @@ const TYPECODES = Dict(
 )
 
 @inline function promote_typecode(T, S)
-    if T == EMPTY || T == S || user(T) || (T == MISSINGTYPE && S == MISSINGTYPE) ||
-        (T & ~MISSING) == (S & ~MISSING)
+    if T == EMPTY || T == S || user(T) || (T & ~MISSING) == (S & ~MISSING)
         return T | S
     elseif T == MISSINGTYPE
         return S | MISSING
@@ -105,8 +104,12 @@ const TYPECODES = Dict(
         return T | MISSING
     elseif T == INT
         return S == FLOAT ? S : S == (FLOAT | MISSING) ? S : missingtype(S) ? (STRING | MISSING) : STRING
+    elseif T == (INT | MISSING)
+        return S == FLOAT || S == (FLOAT | MISSING) ? (FLOAT | MISSING) : (STRING | MISSING)
     elseif T == FLOAT
         return S == INT ? FLOAT : S == (INT | MISSING) ? T | MISSING : missingtype(S) ? (STRING | MISSING) : STRING
+    elseif T == (FLOAT | MISSING)
+        return S == INT || S == (INT | MISSING) ? (FLOAT | MISSING) : (STRING | MISSING)
     elseif missingtype(T) || missingtype(S)
         return STRING | MISSING
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,4 +178,11 @@ CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, nothing, false, rngs,
 
 end
 
+@testset "CSV.promote_typecode" begin
+
+@test CSV.promote_typecode(CSV.INT | CSV.MISSING, CSV.FLOAT) == (CSV.FLOAT | CSV.MISSING)
+@test CSV.promote_typecode(CSV.INT | CSV.MISSING, CSV.FLOAT | CSV.MISSING) == (CSV.FLOAT | CSV.MISSING)
+
+end
+
 end


### PR DESCRIPTION
The issue here is after we've done multithreaded parsing over chunks of
the file, we merge each threads' column types detected to get the
"final column types". The bug here was we didn't have a specific rule if
an earlier thread had detected `Union{Int, Missing}` and a later thread
detected `Float64` or `Union{Float64, Missing}` (and similarly for the
reverse situation, float detected earlier and integers later).

cc: @andreasnoack, @pkofod, this should fix the issue in the file you
shared with me privately