### PR TITLE
Integration column selection directly with parsing

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -78,7 +78,7 @@ struct File{threaded} <: AbstractVector{Row{threaded}}
     rows::Int64
     cols::Int64
     columns::Vector{Union{Column, Column2}}
-    lookup::Dict{Symbol, AbstractVector}
+    lookup::Dict{Symbol, Union{Column, Column2}}
 end
 
 getname(f::File) = getfield(f, :name)
@@ -198,6 +198,7 @@ Supported keyword arguments include:
   * `use_mmap::Bool=!Sys.iswindows()`: whether the file should be mmapped for reading, which in some cases can be faster
   * `ignoreemptylines::Bool=false`: whether empty rows/lines in a file should be ignored (if `false`, each column will be assigned `missing` for that empty row)
   * `threaded::Bool`: whether parsing should utilize multiple threads; by default threads are used on large enough files, but isn't allowed when `transpose=true` or when `limit` is used; only available in Julia 1.3+
+  * `select`: an `AbstractVector` of `Int`, `Symbol`, or `String`, or a "selector" function of the form `(i, name) -> keep::Bool`; only columns in the collection or for which the selector function returns `true` will be parsed and accessible in the resulting `CSV.File`
 * Parsing options:
   * `missingstrings`, `missingstring`: either a `String`, or `Vector{String}` to use as sentinel values that will be parsed as `missing`; by default, only an empty field (two consecutive delimiters) is considered `missing`
   * `delim=','`: a `Char` or `String` that indicates how columns are delimited in a file; if no argument is provided, parsing will try to detect the most consistent delimiter on the first 10 rows of the file
@@ -230,6 +231,8 @@ function File(source;
     comment::Union{String, Nothing}=nothing,
     use_mmap::Bool=!Sys.iswindows(),
     ignoreemptylines::Bool=false,
+    threaded::Union{Bool, Nothing}=nothing,
+    select=nothing,
     # parsing options
     missingstrings=String[],
     missingstring="",
@@ -251,15 +254,14 @@ function File(source;
     pool::Union{Bool, Real}=0.1,
     strict::Bool=false,
     silencewarnings::Bool=false,
-    threaded::Union{Bool, Nothing}=nothing,
     debug::Bool=false,
     parsingdebug::Bool=false,
     allowmissing::Union{Nothing, Symbol}=nothing)
     file(source, header, normalizenames, datarow, skipto, footerskip,
-        limit, transpose, comment, use_mmap, ignoreemptylines, missingstrings, missingstring,
+        limit, transpose, comment, use_mmap, ignoreemptylines, threaded, select, missingstrings, missingstring,
         delim, ignorerepeated, quotechar, openquotechar, closequotechar,
         escapechar, dateformat, decimal, truestrings, falsestrings, type,
-        types, typemap, categorical, pool, strict, silencewarnings, threaded,
+        types, typemap, categorical, pool, strict, silencewarnings,
         debug, parsingdebug, allowmissing)
 end
 
@@ -278,6 +280,8 @@ function file(source,
     comment=nothing,
     use_mmap=!Sys.iswindows(),
     ignoreemptylines=false,
+    threaded=nothing,
+    select=nothing,
     # parsing options
     missingstrings=String[],
     missingstring="",
@@ -299,7 +303,6 @@ function file(source,
     pool=0.1,
     strict=false,
     silencewarnings=false,
-    threaded=nothing,
     debug=false,
     parsingdebug=false,
     allowmissing=nothing)
@@ -425,6 +428,31 @@ function file(source,
     else
         typecodes = TypeCode[T for _ = 1:ncols]
     end
+    # set any unselected columns to typecode USER | MISSING
+    todrop = Int[]
+    if select !== nothing
+        if select isa AbstractVector{Int}
+            foreach(1:ncols) do i
+                i in select || push!(todrop, i)
+            end
+        elseif select isa AbstractVector{Symbol} || select isa AbstractVector{<:AbstractString}
+            select = map(Symbol, select)
+            foreach(1:ncols) do i
+                ix = findfirst(==(names[i]), select)
+                ix === nothing && push!(todrop, i)
+            end
+        elseif select isa Base.Callable
+            foreach(1:ncols) do i
+                select(i, names[i]) || push!(todrop, i)
+            end
+        else
+            error("`select` keyword argument must be an `AbstractVector` of `Int`, `Symbol`, or `String`, or a selector function of the form `(i, name) -> keep::Bool`")
+        end
+    end
+    sort!(unique!(todrop))
+    for i in todrop
+        typecodes[i] = USER | MISSING
+    end
     debug && println("computed typecodes are: $typecodes")
 
     # we now do our parsing pass over the file, starting at datapos
@@ -482,6 +510,10 @@ function file(source,
     else
         columns = Union{Column, Column2}[Column{_eltype(finaltypes[i]), finaltypes[i]}(tapes[i], rows, eq, categorical, finalrefs[i], buf, finaltypes[i] >: Int64 ? uint64(intsentinels[i]) : sentinelvalue(Base.nonmissingtype(finaltypes[i]))) for i = 1:ncols]
     end
+    deleteat!(names, todrop)
+    deleteat!(finaltypes, todrop)
+    ncols -= length(todrop)
+    deleteat!(columns, todrop)
     lookup = Dict(k => v for (k, v) in zip(names, columns))
     return File{something(threaded, false)}(getname(source), names, finaltypes, finalrows, ncols, columns, lookup)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,77 @@ end
 
 @testset "CSV.File with select/drop" begin
 
+csv = """
+a,b,c,d,e
+1,2,3,4,5
+6,7,8,9,10
+"""
 
+f = CSV.File(IOBuffer(csv), select=[1, 3, 5])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), select=[:a, :c, :e])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), select=["a", "c", "e"])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), select=[true, false, true, false, true])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), select=(i, nm) -> i in (1, 3, 5))
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), select=Int[])
+@test length(f) == 2
+@test length(f[1]) == 0
+
+f = CSV.File(IOBuffer(csv), select=[1, 2, 3, 4, 5])
+@test length(f) == 2
+@test length(f[1]) == 5
+
+f = CSV.File(IOBuffer(csv), drop=[2, 4])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), drop=[:b, :d])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), drop=["b", "d"])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), drop=[false, true, false, true, false])
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), drop=(i, nm) -> i in (2, 4))
+@test f.a == [1, 6]
+@test all(f[1] .== [1, 3, 5])
+@test length(f[1]) == 3
+
+f = CSV.File(IOBuffer(csv), drop=Int[])
+@test length(f) == 2
+@test length(f[1]) == 5
+
+f = CSV.File(IOBuffer(csv), drop=[1, 2, 3, 4, 5])
+@test length(f) == 2
+@test length(f[1]) == 0
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,4 +185,10 @@ end
 
 end
 
+@testset "CSV.File with select/drop" begin
+
+
+
+end
+
 end

--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -615,7 +615,7 @@ testfiles = [
     # https://github.com/JuliaData/CSV.jl/issues/575
     ("types_override.csv", (type=Int, types=Dict(:col1 => String)),
         (3, 5),
-        NamedTuple{(:col1,:col2,:col3,:col4,:col5), Tuple{String, Int, Int, Int, Int}},
+        NamedTuple{(:col1,:col2,:col3,:col4,:col5), Tuple{String, Int64, Int64, Int64, Int64}},
         (col1 = ["A", "B", "C"], col2 = [1, 5, 9], col3 = [2, 6, 10], col4 = [3, 7, 11], col5 = [4, 8, 12])
     )
 ];


### PR DESCRIPTION
Implements #557.

We've always had the ability to do fairly efficient column selection
post-parsing on a `CSV.File` object via `Tables.select` (now
`TableOperations.select`), but this still meant parsing the full file,
which, depending on the column type, could be a little costly.

With this PR, we introduce a `select` keyword argument to
`CSV.read`/`CSV.File` which allows passing a list of columns as an
`AbstractVector{Int}`, `AbstractVector{Symbol}`, or
`AbstractVector{String}`, or as a "selector" function of the form `(i,
name) -> keep::Bool` to specify which columns to "keep" after parsing.
Internally, this utilizes a trick we already had in place wherein if a
column type is user-specified as `Missing`, then parsing efficiently
"skips" any type parsing for that column (basically just moves our
parsing state past the cell). So in terms of implementation, this is
surprisingly simple: for any column we don't want to "select", we set
it's column type upfront to `Missing`, parse the file, then remove any
mention of the dropped columns in the final `CSV.File` object.

TODO items left on this PR include:
* Does this API look sound/safe/whole? cc: @nalimilan, @bkamins
* Tests
* Examples