### PR TITLE
Allow passing types to CSV.Rows

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -243,10 +243,7 @@ function File(source;
         finalrows = rows
         debug && println("time for initial parsing to tape: $(Base.time() - t)")
     end
-    for i = 1:ncols
-        typecodes[i] &= ~USER
-    end
-    finaltypes = Type[TYPECODES[T] for T in typecodes]
+    finaltypes = Type[gettype(T) for T in typecodes]
     debug && println("types after parsing: $finaltypes, pool = $pool")
     finalrefs = Vector{Union{Vector{String}, Nothing}}(undef, ncols)
     if pool > 0.0
@@ -525,7 +522,7 @@ end
                     options.silencewarnings || notenoughcolumns(col, ncols, row)
                     for j = (col + 1):ncols
                         # put in dummy missing values on the tape for missing columns
-                        if !usermissing(T)
+                        if !usermissing(typecodes[j])
                             @inbounds tape = tapes[j]
                             T = typebits(typecodes[j])
                             tape[row] = T == POOL ? 0 : T == INT ? uint64(intsentinels[j]) : sentinelvalue(TYPECODES[T])

--- a/src/file.jl
+++ b/src/file.jl
@@ -681,7 +681,7 @@ function detect(tape, buf, pos, len, options, row, col, typemap, pool, refs, las
     return pos + tlen, code
 end
 
-@inline function parseint!(T, tape, buf, pos, len, options, row, col, typecodes, poslens, intsentinels)
+function parseint!(T, tape, buf, pos, len, options, row, col, typecodes, poslens, intsentinels)
     x, code, vpos, vlen, tlen = Parsers.xparse(Int64, buf, pos, len, options)
     if code > 0
         if !Parsers.sentinel(code)
@@ -805,7 +805,7 @@ end
     return pos + tlen, code
 end
 
-@inline function parsemissing!(buf, pos, len, options, row, col)
+function parsemissing!(buf, pos, len, options, row, col)
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     if Parsers.invalidquotedfield(code)
         # this usually means parsing is borked because of an invalidly quoted field, hard error
@@ -814,7 +814,7 @@ end
     return pos + tlen, code
 end
 
-@inline function getref!(x::Dict, key::PointerString, lastrefs, col, code, options)
+function getref!(x::Dict, key::PointerString, lastrefs, col, code, options)
     if Parsers.escapedstring(code)
         key2 = unescape(key, options.e)
         index = Base.ht_keyindex2!(x, key2)
@@ -831,7 +831,7 @@ end
     end
 end
 
-@inline function parsepooled!(T, tape, buf, pos, len, options, row, col, rowsguess, pool, refs, lastrefs, typecodes, poslens)
+function parsepooled!(T, tape, buf, pos, len, options, row, col, rowsguess, pool, refs, lastrefs, typecodes, poslens)
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     if Parsers.invalidquotedfield(code)
         # this usually means parsing is borked because of an invalidly quoted field, hard error

--- a/src/header.jl
+++ b/src/header.jl
@@ -193,6 +193,14 @@ end
     else
         typecodes = TypeCode[T for _ = 1:ncols]
     end
+    if streaming
+        for i = 1:ncols
+            T = typecodes[i]
+            if pooled(T)
+                typecodes[i] = STRING | (T & MISSING)
+            end
+        end
+    end
     # set any unselected columns to typecode USER | MISSING
     todrop = Int[]
     if select !== nothing && drop !== nothing

--- a/src/header.jl
+++ b/src/header.jl
@@ -42,7 +42,6 @@ end
     # header can be a row number, range of rows, or actual string vector
     header,
     normalizenames,
-    # by default, data starts immediately after header or start of file
     datarow,
     skipto,
     footerskip,
@@ -183,7 +182,7 @@ end
     debug && println("byte position of data computed at: $datapos")
 
     # deduce initial column types for parsing based on whether any user-provided types were provided or not
-    T = type === nothing ? (streaming ? STRING : EMPTY) : (typecode(type) | USER)
+    T = type === nothing ? (streaming ? (STRING | MISSING) : EMPTY) : (typecode(type) | USER)
     if types isa Vector
         typecodes = TypeCode[typecode(T) | USER for T in types]
         categorical = categorical | any(x->x == CategoricalString{UInt32}, types)
@@ -197,6 +196,7 @@ end
         for i = 1:ncols
             T = typecodes[i]
             if pooled(T)
+                @warn "pooled column types not allowed in `CSV.Rows` (column number = $i)"
                 typecodes[i] = STRING | (T & MISSING)
             end
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,6 +95,8 @@ const TYPECODES = Dict(
     STRING | MISSING => Union{String, Missing}
 )
 
+gettype(x::TypeCode) = TYPECODES[x & ~USER]
+
 @inline function promote_typecode(T, S)
     if T == EMPTY || T == S || user(T) || (T & ~MISSING) == (S & ~MISSING)
         return T | S


### PR DESCRIPTION
We already allow fairly efficient means of parsing typed values when
iterating via `CSV.Rows` with `Parsers.parse` and `CSV.detect`
definitions, but ideally, you could pass your own types that you care
about to `CSV.Rows` and have them parsed while iterating/consuming the
file.

To do this properly and not cause massive code duplication, it's
required refactoring things quite a bit to share a lot of common logic
between CSV.File and CSV.Rows (hence a previous PR to introduce
CSV.Header). This PR further refactors things so that CSV.File and
CSV.Row use the same core `parserow` method for consuming a single row
of a file.

One potential downside is that we're changing CSV.Rows from using a
single contiguous `Vector{UInt64}` as a tape, to using a
`Vector{Vector{UInt64}`, where each element vector has length 1. It's
not clear to me what kind of memory cache line penalty we might pay, but
I plan on doing some benchmarking to try and see if it's drastic
(computers are pretty smart these days, so hopefully it's fine).

Otherwise, the changes here aren't too drastic; mainly the refactoring
and then the "value access" functions changing from always returning
Strings, to returning the typed value if there was one.

I need to add some additional tests here, and generally benchmark/kick
the tires to see if anything else shakes out, but seems to work fairly
well so far.