### PR TITLE
Support different dateformats per column

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -193,7 +193,7 @@ end
     elseif dateformats isa AbstractDict{Int}
         coloptions = [haskey(dateformats, i) ? Parsers.Options(sentinel, wh1, wh2, oq, cq, eq, d, decimal, trues, falses, dateformats[i], ignorerepeated, ignoreemptylines, comment, true, parsingdebug, strict, silencewarnings) : options for i = 1:ncols]
     end
-    debug && println("column options generated as: $coloptions")
+    debug && println("column options generated as: $(something(coloptions, ""))")
 
     # deduce initial column types for parsing based on whether any user-provided types were provided or not
     T = type === nothing ? (streaming ? (STRING | MISSING) : EMPTY) : (typecode(type) | USER)

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -163,7 +163,7 @@ const EMPTY_LASTREFS = UInt64[]
     tapes = r.reusebuffer ? r.tapes : [Vector{UInt64}(undef, usermissing(r.typecodes[i]) ? 0 : 1) for i = 1:r.cols]
     pos = parserow(1, Val(transpose), r.cols, EMPTY_TYPEMAP, tapes, EMPTY_POSLENS, r.buf, pos, len, r.limit, r.positions, 0.0, EMPTY_REFS, EMPTY_LASTREFS, 0, r.typecodes, r.intsentinels, false, r.options, r.coloptions)
     intsentinels = r.reusebuffer ? r.intsentinels : copy(r.intsentinels)
-    return Row2(r.names, r.types, r.columnmap, r.typecodes, r.lookup, tapes, r.buf, r.e, r.options, intsentinels), (pos, len, row + 1)
+    return Row2(r.names, r.types, r.columnmap, r.typecodes, r.lookup, tapes, r.buf, r.e, r.options, r.coloptions, intsentinels), (pos, len, row + 1)
 end
 
 struct Row2{O} <: Tables.AbstractRow

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -15,6 +15,7 @@ struct Rows{transpose, O, IO}
     len::Int
     limit::Int64
     options::O # Parsers.Options
+    coloptions::Union{Nothing, Vector{Parsers.Options}}
     positions::Vector{Int64}
     reusebuffer::Bool
     tapes::Vector{Vector{UInt64}}
@@ -98,6 +99,7 @@ function Rows(source;
     closequotechar::Union{UInt8, Char, Nothing}=nothing,
     escapechar::Union{UInt8, Char}='"',
     dateformat::Union{String, Dates.DateFormat, Nothing}=nothing,
+    dateformats::Union{AbstractDict, Nothing}=nothing,
     decimal::Union{UInt8, Char}=UInt8('.'),
     truestrings::Union{Vector{String}, Nothing}=nothing,
     falsestrings::Union{Vector{String}, Nothing}=nothing,
@@ -114,7 +116,7 @@ function Rows(source;
     reusebuffer::Bool=false,
     kw...)
 
-    h = Header(source, header, normalizenames, datarow, skipto, footerskip, limit, transpose, comment, use_mmap, ignoreemptylines, false, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, decimal, truestrings, falsestrings, type, types, typemap, categorical, pool, strict, silencewarnings, debug, parsingdebug, true)
+    h = Header(source, header, normalizenames, datarow, skipto, footerskip, limit, transpose, comment, use_mmap, ignoreemptylines, false, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, categorical, pool, strict, silencewarnings, debug, parsingdebug, true)
     tapes = [Vector{UInt64}(undef, usermissing(h.typecodes[i]) ? 0 : 1) for i = 1:h.cols]
     types = Type[gettype(T) for T in h.typecodes]
     columnmap = [i for i = 1:h.cols]
@@ -135,6 +137,7 @@ function Rows(source;
         h.len,
         limit,
         h.options,
+        h.coloptions,
         h.positions,
         reusebuffer,
         tapes,
@@ -158,7 +161,7 @@ const EMPTY_LASTREFS = UInt64[]
     (pos > len || row > r.limit) && return nothing
     pos > len && return nothing
     tapes = r.reusebuffer ? r.tapes : [Vector{UInt64}(undef, usermissing(r.typecodes[i]) ? 0 : 1) for i = 1:r.cols]
-    pos = parserow(1, Val(transpose), r.cols, EMPTY_TYPEMAP, tapes, EMPTY_POSLENS, r.buf, pos, len, r.limit, r.positions, 0.0, EMPTY_REFS, EMPTY_LASTREFS, 0, r.typecodes, r.intsentinels, false, r.options)
+    pos = parserow(1, Val(transpose), r.cols, EMPTY_TYPEMAP, tapes, EMPTY_POSLENS, r.buf, pos, len, r.limit, r.positions, 0.0, EMPTY_REFS, EMPTY_LASTREFS, 0, r.typecodes, r.intsentinels, false, r.options, r.coloptions)
     intsentinels = r.reusebuffer ? r.intsentinels : copy(r.intsentinels)
     return Row2(r.names, r.types, r.columnmap, r.typecodes, r.lookup, tapes, r.buf, r.e, r.options, intsentinels), (pos, len, row + 1)
 end
@@ -173,6 +176,7 @@ struct Row2{O} <: Tables.AbstractRow
     buf::Vector{UInt8}
     e::UInt8
     options::O
+    coloptions::Union{Nothing, Vector{Parsers.Options}}
     intsentinels::Vector{Int64}
 end
 
@@ -185,6 +189,7 @@ gettapes(r::Row2) = getfield(r, :tapes)
 getbuf(r::Row2) = getfield(r, :buf)
 gete(r::Row2) = getfield(r, :e)
 getoptions(r::Row2) = getfield(r, :options)
+getcoloptions(r::Row2) = getfield(r, :coloptions)
 getintsentinels(r::Row2) = getfield(r, :intsentinels)
 
 Tables.columnnames(r::Row2) = getnames(r)
@@ -247,7 +252,9 @@ Base.@propagate_inbounds function Parsers.parse(::Type{T}, r::Row2, i::Int) wher
     @inbounds offlen = gettapes(r)[j][1]
     missingvalue(offlen) && return missing
     pos = getpos(offlen)
-    x, code, vpos, vlen, tlen = Parsers.xparse(T, getbuf(r), pos, pos + getlen(offlen), getoptions(r))
+    colopts = getcoloptions(r)
+    opts = colopts === nothing ? getoptions(r) : colopts[j]
+    x, code, vpos, vlen, tlen = Parsers.xparse(T, getbuf(r), pos, pos + getlen(offlen), opts)
     return Parsers.ok(code) ? x : missing
 end
 
@@ -259,7 +266,9 @@ Base.@propagate_inbounds function detect(r::Row2, i::Int)
     @inbounds offlen = gettapes(r)[j][1]
     missingvalue(offlen) && return missing
     pos = getpos(offlen)
-    x = detect(getbuf(r), pos, pos + getlen(offlen) - 1, getoptions(r))
+    colopts = getcoloptions(r)
+    opts = colopts === nothing ? getoptions(r) : colopts[j]
+    x = detect(getbuf(r), pos, pos + getlen(offlen) - 1, opts)
     return x === nothing ? r[i] : x
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -396,4 +396,11 @@ df = CSV.read(IOBuffer("h1234567890123456\t"^2262 * "lasthdr\r\n" *"dummy dummy 
 @test size(df) == (10, 2263)
 @test all(x -> eltype(x) == Float64, eachcol(df))
 
+# multiple dateformats
+f = CSV.File(IOBuffer("time,date,datetime\n10:00:00.0,04/16/2020,2020-04-16 23:14:00\n"), dateformats=Dict(2=>"mm/dd/yyyy", 3=>"yyyy-mm-dd HH:MM:SS"))
+@test length(f) == 1
+@test f[1].time == Dates.Time(10)
+@test f[1].date == Dates.Date(2020, 4, 16)
+@test f[1].datetime == Dates.DateTime(2020, 4, 16, 23, 14)
+
 end


### PR DESCRIPTION
This has been long requested, but the internal structure always assumed
that we'd only ever need a single `Parsers.Options` for an entire file.
For certain parsing features, like date formats, they can vary column to
column, so it makes sense to allow specifying options for a specific
column. This isn't too onerous internally, because we're currently
restricting the option to just dateformats; theoretically we could open
up additional options that may affect a column's type like truestrings,
falsestrings, decimal, and missingstring (though for several of these,
you can already specify multiple options, but this would allow, for
example, specifying a missing string for one column and a different
missingstring for another, without overlap).

I'm limiting to just multiple dateformats for now to kind of kick the
tires and see how minimal of a change we can make this to support the
actual requested feature, but I'm interested to see if we want any other
parsing options to be configurable per column in the future.