### PR TITLE
Allow custom callbacks for invalid row/cell

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -403,4 +403,13 @@ f = CSV.File(IOBuffer("time,date,datetime\n10:00:00.0,04/16/2020,2020-04-16 23:1
 @test f[1].date == Dates.Date(2020, 4, 16)
 @test f[1].datetime == Dates.DateTime(2020, 4, 16, 23, 14)
 
+# manual invalid cell and invalid row callbacks
+invalidcells = []
+invalidrows = []
+f = CSV.File(IOBuffer("a,b,c\n1.0,\nhey,2,3\n"), types=Dict(1=>Float64), invalidrow=row->push!(invalidrows, row), invalidcell=(args...)->push!(invalidcells, args))
+@test length(invalidrows) == 1
+@test invalidrows[1] == 1
+@test length(invalidcells) == 1
+@test invalidcells[1] == (Int64, "hey,", -32630, 2, 1)
+
 end


### PR DESCRIPTION
This implements #522. It allows providing two different callbacks:

* `invalidrow`: a callback that takes a single `Integer` representing
the row number where an invalid state was detected (not enough columns
parsed or more columns than expected were detected)

* `invalidcell`: a callback called when an error occurs parsing a
user-provided type (Int, Float64, Bool, Date, DateTime, or Time); the
callback should take 5 arguments: 1) the type attempted while parsing,
2) a string of the cell where parsing failed, 3) a Parsers.jl `code`
return code value that encodes events/states that occurred while
parsing, 4) the row the invalid cell was on, and 5) the column the
invalid cell was on.

Providing an `invalidrow` or `invalidcell` function forces
`silencewarnings=true` for invalid rows or cells, respectively, i.e. no
warning will be printed if an error callback function is provided.

If `strict=true` is provided, `invalidcell` will not be invoked.

This PR includes a simple test, but no docs yet.