### PR TITLE
Check for write buffer overflow and throw error

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -242,8 +242,11 @@ function with(f::Function, file::Union{AbstractString, AbstractPath}, append)
     end
 end
 
+@noinline buffertoosmall(pos, len) = throw(ArgumentError("row size ($pos) too large for writing buffer ($len), pass a larger value to `bufsize` keyword argument"))
+
 macro check(n)
     esc(quote
+        $n > length(buf) && buffertoosmall(pos + $n - 1, length(buf))
         if (pos + $n - 1) > len
             Base.write(io, view(buf, 1:(pos - 1)))
             pos = 1

--- a/test/write.jl
+++ b/test/write.jl
@@ -312,4 +312,8 @@ const table_types = (
     close(io)
     @test read(io, String) == "a,b\n1,4.1\n2,5.2\n3,6.3\n"
 
+    # https://github.com/JuliaData/CSV.jl/issues/643
+    s = join(1:1000000);
+    @test_throws ArgumentError CSV.write("out.test.csv", [(a=s,)])
+
 end # @testset "CSV.write"


### PR DESCRIPTION
Previously, we relied on a BoundsError to be thrown, but that can be
cryptic for users who inadvertently hit the internal buffer size limit.
Fixes #643 by throwing a more descriptive, helpful error.