### PR TITLE
Improve error row reporting

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -7,6 +7,7 @@ struct Header{transpose, O, IO}
     buf::IO
     len::Int
     datapos::Int64
+    datarow::Int
     options::O # Parsers.Options
     coloptions::Union{Nothing, Vector{Parsers.Options}}
     positions::Vector{Int64}
@@ -286,6 +287,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         buf,
         len,
         datapos,
+        datarow,
         options,
         coloptions,
         positions,


### PR DESCRIPTION
Fixes #642. There were a couple of problems with our error/warnings
reporting which row was affected. We weren't accounting for any initial
data row offsets. For multithreading, this is a tricky problem because
each chunk doesn't inherently know which absolute row it's parsing when
it encounters a problem. For now, we pass in the "guess" of which row
we're on based on the estimated # of rows. It's not amazingly accurate
by any means, but should at least get the general ballpark. The other
consolation is that in non-threaded mode or CSV.Rows, the row #
reporting should be exact, if you really need to track down a
problematic row.