### PR TITLE
Deprecate Cmd and generic IO inputs to CSV.File/CSV.Rows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.6.2"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 CategoricalArrays = "0.8"
@@ -28,8 +26,10 @@ julia = "1"
 
 [extras]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["Test", "Random", "CodecZlib"]
+test = ["Test", "Random", "CodecZlib", "FilePathsBase", "WeakRefStrings"]

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -9,8 +9,6 @@ using Parsers
 using Tables
 # PooledArrays.jl is used for materializing pooled columns
 using PooledArrays
-# FilePathBase allows passing FilePaths instead of just strings for the file name
-using FilePathsBase
 # WeakRefStrings allows for more efficient materializing of string columns via StringVector
 using WeakRefStrings
 using SentinelArrays

--- a/src/file.jl
+++ b/src/file.jl
@@ -287,6 +287,9 @@ function File(source;
     ncols -= length(h.todrop)
     deleteat!(columns, h.todrop)
     lookup = Dict(k => v for (k, v) in zip(h.names, columns))
+    if Sys.iswindows() && !lazystrings
+        finalize(buf)
+    end
     return File{something(threaded, false)}(h.name, h.names, types, finalrows, ncols, columns, lookup)
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -236,7 +236,7 @@ function with(f::Function, io::Union{Base.TTY, Base.Pipe, Base.PipeEndpoint, Bas
     f(io)
 end
 
-function with(f::Function, file::Union{AbstractString, AbstractPath}, append)
+function with(f::Function, file, append)
     open(file, append ? "a" : "w") do io
         f(io)
     end


### PR DESCRIPTION
When parsing, CSV.File/CSV.Rows require an `AbstractVector{UInt8}`. For
`Cmd` and generic `IO` arguments, it's always been a little awkward
because we basically just tried to read the whole thing or had this
weird slurp function that tried to read it all in chunks. This led to a
few surprises for users when their system ran out of memory.

This PR deprecates passing `Cmd` and generic `IO` arguments as inputs,
stating the user should instead do `read(x)` first or find another way
to pass a filename in. I think this will overall lead to less surprises
for users and requiring them to do `read(x)` themselves isn't too
onerous and gives them the chance to read it themselves if that works
for their use-case or find a more efficient way to pass the data in.

This also deprecates the `use_mmap` keyword argument, since we'll mmap
every time a filename is passed in. You can "avoid" this by calling
`read(open(file))` yourself if so needed, but `CSV.File` doesn't hold on
to a reference of the mmapped file any more (unless `lazystrings=true`),
so we shouldn't run into some of the issues we have in the past.

We also cleanup some dependencies here by moving FilePathsBase.jl and
WeakRefStrings.jl to test-only dependencies, since they're not used
internally in CSV.jl anymore.

One last note is that `IOBuffer` is still allowed to be passed as an
input argument since it's basically just a byte buffer underneath
anyway, so we can use the data directly.