### PR TITLE
Improve CSV.Rows performance

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 
  [compat]
-Documenter = "~0.22"
+Documenter = "0.23"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,5 @@
 using Documenter, CSV
 
-makedocs(
-    modules = [CSV],
-    sitename = "CSV.jl",
-    pages = ["Home" => "index.md"]
-)
+makedocs(modules = [CSV], sitename = "CSV.jl")
 
-deploydocs(
-    repo = "github.com/JuliaData/CSV.jl.git",
-    target = "build"
-)
+deploydocs(repo = "github.com/JuliaData/CSV.jl.git")

--- a/src/file.jl
+++ b/src/file.jl
@@ -596,7 +596,7 @@ end
     end
 end
 
-@inline function parserow(row, TR::Val{transpose}, ncols, typemap, tapes, startpos, buf, pos, len, positions, pool, refs, rowsguess, rowoffset, types, flags, debug, options::Parsers.Options{ignorerepeated}, coloptions, ::Type{customtypes}) where {transpose, ignorerepeated, customtypes}
+@inline function parserow(row, TR::Val{transpose}, ncols, typemap, tapes, startpos, buf, pos::A, len, positions, pool, refs, rowsguess, rowoffset, types, flags, debug, options::B, coloptions::C, ::Type{customtypes}) where {transpose, A, B, C, customtypes}
     for col = 1:ncols
         if transpose
             @inbounds pos = positions[col]
@@ -782,7 +782,7 @@ function detect(tapes, buf, pos, len, options, row, rowoffset, col, typemap, poo
     return pos + tlen, code
 end
 
-function parseint!(flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, types, flags)
+function parseint!(flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, types, flags)::Tuple{Int64, Int16}
     x, code, vpos, vlen, tlen = Parsers.xparse(Int64, buf, pos, len, options)
     if code > 0
         if !Parsers.sentinel(code)
@@ -822,7 +822,7 @@ function parseint!(flag, tape, tapes, buf, pos, len, options, row, rowoffset, co
     return pos + tlen, code
 end
 
-function parsevalue!(::Type{type}, flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, types, flags) where {type}
+function parsevalue!(::Type{type}, flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, types, flags)::Tuple{Int64, Int16} where {type}
     x, code, vpos, vlen, tlen = Parsers.xparse(type, buf, pos, len, options)
     if code > 0
         if !Parsers.sentinel(code)
@@ -853,7 +853,7 @@ function parsevalue!(::Type{type}, flag, tape, tapes, buf, pos, len, options, ro
     return pos + tlen, code
 end
 
-function parsestring!(flag, tape, buf, pos, len, options, row, rowoffset, col, types, flags)
+function parsestring!(flag, tape, buf, pos, len, options, row, rowoffset, col, types, flags)::Tuple{Int64, Int16}
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     setposlen!(tape, row, code, vpos, vlen)
     if Parsers.invalidquotedfield(code)
@@ -869,7 +869,7 @@ function parsestring!(flag, tape, buf, pos, len, options, row, rowoffset, col, t
     return pos + tlen, code
 end
 
-function parsestring2!(flag, tape, buf, pos, len, options, row, rowoffset, col, types, flags)
+function parsestring2!(flag, tape, buf, pos, len, options, row, rowoffset, col, types, flags)::Tuple{Int64, Int16}
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     if Parsers.invalidquotedfield(code)
         # this usually means parsing is borked because of an invalidly quoted field, hard error
@@ -886,7 +886,7 @@ function parsestring2!(flag, tape, buf, pos, len, options, row, rowoffset, col, 
     return pos + tlen, code
 end
 
-function parsemissing!(buf, pos, len, options, row, rowoffset, col)
+function parsemissing!(buf, pos, len, options, row, rowoffset, col)::Tuple{Int64, Int16}
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     if Parsers.invalidquotedfield(code)
         # this usually means parsing is borked because of an invalidly quoted field, hard error
@@ -920,7 +920,7 @@ end
     return ret
 end
 
-function parsepooled!(flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, rowsguess, pool, refs, types, flags)
+function parsepooled!(flag, tape, tapes, buf, pos, len, options, row, rowoffset, col, rowsguess, pool, refs, types, flags)::Tuple{Int64, Int16}
     x, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
     if Parsers.invalidquotedfield(code)
         # this usually means parsing is borked because of an invalidly quoted field, hard error

--- a/src/header.jl
+++ b/src/header.jl
@@ -277,7 +277,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         end
     end
     for i in todrop
-        flags[i] = WILLDROP
+        flags[i] |= WILLDROP
     end
     debug && println("computed types are: $types")
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -151,7 +151,7 @@ end
 const SmallIntegers = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32}
 
 function allocate(rowsguess, ncols, types, flags)
-    return AbstractVector[allocate(lazystrings(flags[i]) && types[i] >: String ? PosLen : types[i], rowsguess) for i = 1:ncols]
+    return AbstractVector[allocate(lazystrings(flags[i]) && (types[i] === String || types[i] === Union{String, Missing}) ? PosLen : types[i], rowsguess) for i = 1:ncols]
 end
 
 allocate(::Type{Union{}}, len) = MissingVector(len)


### PR DESCRIPTION
Looks like we accumulated some performance regressions for CSV.Rows;
this fixes most of them. There's still some extra allocations that
happen when passing custom types, but it's not too bad and can be solve
another day.