### PR TITLE
When column names passed manually, ensure we respect starting position

### DIFF
--- a/src/detection.jl
+++ b/src/detection.jl
@@ -16,7 +16,7 @@ function detectheaderdatapos(buf, pos, len, oq, eq, cq, cmt, ignoreemptylines, h
         headerpos = checkcommentandemptyline(buf, headerpos, len, cmt, ignoreemptylines)
         datapos = skiptorow(buf, headerpos, len, oq, eq, cq, header[1], datarow)
     elseif header isa Union{AbstractVector{Symbol}, AbstractVector{String}}
-        datapos = skiptorow(buf, 1, len, oq, eq, cq, 1, datarow)
+        datapos = skiptorow(buf, pos, len, oq, eq, cq, 1, datarow)
     else
         throw(ArgumentError("unsupported header argument: $header"))
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -482,4 +482,16 @@ for chunk in chunks
 end
 @test rows == 10000
 
+# 668
+buf = IOBuffer("""
+       garbage
+       a,b
+       1,2
+       """)
+readline(buf)
+f = CSV.File(buf, header=["A", "B"])
+@test length(f) == 2
+@test f.names == [:A, :B]
+@test (f[1].A, f[1].B) == ("a", "b")
+@test (f[2].A, f[2].B) == ("1", "2")
 end


### PR DESCRIPTION
Fixes #668. The issue here is that when column names were passed
manually, the code path that "skipped" to the datarow passed in the
starting position as 1 instead of `pos` variable. This used to not be an
issue because the `pos` was almost always 1 anyway. With `IOBuffer`, we
now start `pos` at `io.ptr`, so we'll have more cases where it's
critical to start reading at right position.