### PR TITLE
Improve accuracy of estimated rows for multithreaded parsing

### DIFF
--- a/src/detection.jl
+++ b/src/detection.jl
@@ -307,6 +307,8 @@ end
 # at the byte position, assuming we were in the a quoted field (and encountered a newline inside the quoted
 # field the first time through)
 function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, ranges, ncols) where {ignorerepeated}
+    totalbytes = 0
+    totalrows = 0
     for i = 2:(length(ranges) - 1)
         pos = ranges[i]
         while pos <= len
@@ -323,6 +325,7 @@ function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, rang
                 end
             end
             # now we read the next 5 rows and see if we get the right # of columns
+            rowstartpos = pos
             correct = true
             for j = 1:5
                 for _ = 1:ncols
@@ -334,6 +337,8 @@ function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, rang
             end
             if correct
                 # boom, we read a whole row and got correct # of columns
+                totalbytes += pos - rowstartpos
+                totalrows += 5
                 break
             end
             # else, assume we were inside a quoted field:
@@ -378,7 +383,7 @@ function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, rang
             end
         end
     end
-    return
+    return totalbytes / totalrows
 end
 
 function detecttranspose(buf, pos, len, options, header, datarow, normalizenames)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -108,7 +108,7 @@ rows = collect(CSV.File(joinpath(dir, "time.csv"); dateformat="H:M:S"))
 @test rows[2].time == Time(0, 10)
 
 # 388
-f = CSV.File(joinpath(dir, "GSM2230757_human1_umifm_counts.csv"))
+f = CSV.File(joinpath(dir, "GSM2230757_human1_umifm_counts.csv"); threaded=false)
 @test length(f.names) == 20128
 @test length(f) == 3
 


### PR DESCRIPTION
I've wanted to do this for a while; previously we were only using the
estimate from the first 10 rows. This hooks into the "chunking" code,
which looks at `tasks` # of chunks of a file to find the start of rows
for each; we now keep track of the # of bytes we saw when doing those
row checks and use those totals plus the original 10 rows to form a
better estimate of the total # of rows.