### PR TITLE
Ensure dropped columns are ignored in later file processing

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -277,7 +277,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         end
     end
     for i in todrop
-        flags[i] |= WILLDROP
+        flags[i] |= WILLDROP | ANYMISSING
     end
     debug && println("computed types are: $types")
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -511,4 +511,8 @@ f = CSV.File(IOBuffer("""x,y
 @test f.x[end] === missing
 @test f.y[end] === missing
 
+# 679
+f = CSV.File(IOBuffer("a,b,c\n1,2,3\n4,5,6\n"); select=["a"], types=Dict(2=>Int8))
+@test f.a == [1, 4]
+
 end


### PR DESCRIPTION
Fixes #679; alternative fix to #681. When a column is dropped, we
essentially turn it into a `Missing` column type and ignore it when
parsing. There was a check later in file parsing, however, that said if
no missing values were found in a column, to ensure its type is
`Vector{T}` instead of `Vector{Union{Missing, T}}`. The core problem in
issue #679 was that these dropped columns, while completely `missing`,
didn't get "flagged" as having `missing` values.