### PR TITLE
Fix typemap for our new custom types world

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -70,7 +70,7 @@ function Chunks(source;
     parsingdebug::Bool=false)
 
     limit=typemax(Int64)
-    h = Header(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, use_mmap, ignoreemptylines, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, categorical, pool, lazystrings, strict, silencewarnings, debug, parsingdebug, false)
+    h = Header(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, use_mmap, ignoreemptylines, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, categorical, pool, lazystrings, strict, silencewarnings, debug, parsingdebug, false)
     rowsguess, ncols, buf, len, datapos, options = h.rowsguess, h.cols, h.buf, h.len, h.datapos, h.options
     N = tasks > rowsguess || rowsguess < 100 ? 1 : tasks == 1 ? 8 : tasks
     chunksize = div(len - datapos, N)

--- a/src/header.jl
+++ b/src/header.jl
@@ -78,6 +78,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
     # type options
     type,
     types,
+    typemap,
     categorical,
     pool,
     lazystrings,
@@ -228,7 +229,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         end
     end
     # generate a customtypes Tuple{...} we'll need to generate code for during parsing
-    customtypes = Tuple{(nonstandardtype(T) for T in types if nonstandardtype(T) !== Union{})...}
+    customtypes = Tuple{(nonstandardtype(T) for T in vcat(types, values(typemap)...) if nonstandardtype(T) !== Union{})...}
     # figure out if we'll drop any columns while parsing
     todrop = Int[]
     if select !== nothing && drop !== nothing

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -139,7 +139,7 @@ function Rows(source;
     reusebuffer::Bool=false,
     kw...)
 
-    h = Header(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, use_mmap, ignoreemptylines, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, categorical, pool, lazystrings, strict, silencewarnings, debug, parsingdebug, true)
+    h = Header(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, use_mmap, ignoreemptylines, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, categorical, pool, lazystrings, strict, silencewarnings, debug, parsingdebug, true)
     columns = allocate(1, h.cols, h.types, h.flags, nothing)
     values = all(x->x == Union{String, Missing}, h.types) && lazystrings ? Vector{PosLen}(undef, h.cols) : Vector{Any}(undef, h.cols)
     finaltypes = copy(h.types)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -495,6 +495,12 @@ f = CSV.File(buf, header=["A", "B"])
 @test (f[1].A, f[1].B) == ("a", "b")
 @test (f[2].A, f[2].B) == ("1", "2")
 
+# 680: ensure typemap works with custom types
+f = CSV.File(IOBuffer("a\n1\n2\n3"); typemap=Dict(Int64=>Int32))
+@test f.a isa Vector{Int32}
+f = CSV.File(IOBuffer("a\n1\n2\n3"); typemap=Dict(Int64=>String))
+@test f.a isa Vector{String}
+
 # 678
 f = CSV.File(IOBuffer("""x,y
                                        a,b


### PR DESCRIPTION
Fixes #680. Before custom types, the `typemap` keyword argument was
really only about mapping between the standard, supported types. With
custom types, we still only support certain type mappings (Int to Float,
Any type to String), but we also want to support type mappings like
`Int64 => Int32`. This PR readjusts how typemap works when detecting
column types to account for the possiblity of custom Integer or
AbstractFloat type mappints for Int64 & Float64, and moving directly to
String if that's specified.