### PR TITLE
Fix case when type is provided for dropped columns

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -279,6 +279,7 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
     end
     for i in todrop
         flags[i] |= WILLDROP | ANYMISSING
+        types[i] = Missing
     end
     debug && println("computed types are: $types")
     pool = pool === true ? 1.0 : pool isa Float64 ? pool : 0.0

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -375,7 +375,7 @@ end
 @test columntable(CSV.File(`$(catcmd) $(joinpath(dir, "test_basic.csv"))`)) == columntable(CSV.File(joinpath(dir, "test_basic.csv")))
 
 #476
-f = CSV.File(GzipDecompressorStream(open(joinpath(dir, "randoms.csv.gz"))))
+f = CSV.File(transcode(GzipDecompressor, Mmap.mmap(joinpath(dir, "randoms.csv.gz"))))
 @test (length(f), length(f.names)) == (70000, 7)
 
 f = CSV.File(IOBuffer("thistime\n10:00:00.0\n12:00:00.0"))
@@ -428,7 +428,7 @@ f = CSV.File(
 @test f.csvstring isa CSV.SVec2{CSVString}
 @test isequal(f.csvstring, [CSVString("hey there sailor"), missing])
 
-f = CSV.File(GzipDecompressorStream(open(joinpath(dir, "randoms.csv.gz"))); types=[Int32, CSVString, String, Float64, Dec64, Date, DateTime])
+f = CSV.File(transcode(GzipDecompressor, Mmap.mmap(joinpath(dir, "randoms.csv.gz"))); types=[Int32, CSVString, String, Float64, Dec64, Date, DateTime])
 @test f.id isa AbstractVector{Int32}
 @test f.first isa AbstractVector{CSVString}
 @test f.wage isa AbstractVector{Union{Missing, Dec64}}
@@ -520,5 +520,9 @@ f = CSV.File(IOBuffer("""x,y
 # 679
 f = CSV.File(IOBuffer("a,b,c\n1,2,3\n4,5,6\n"); select=["a"], types=Dict(2=>Int8))
 @test f.a == [1, 4]
+
+f = CSV.File(transcode(GzipDecompressor, Mmap.mmap(joinpath(dir, "randoms.csv.gz"))); types=Dict(:id=>Int32), select=["first"])
+@test length(f) == 70000
+@test eltype(f.first) == String
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, CSV, Dates, Tables, CategoricalArrays, PooledArrays, CodecZlib, FilePathsBase, SentinelArrays, Parsers
+using Test, CSV, Mmap, Dates, Tables, CategoricalArrays, PooledArrays, CodecZlib, FilePathsBase, SentinelArrays, Parsers
 
 const dir = joinpath(dirname(pathof(CSV)), "..", "test", "testfiles")
 


### PR DESCRIPTION
Additional fix for #679. There was an alternative issue discovered in
 #679 where a type was given for a dropped column, like `CSV.File(file;
 types=Dict(:id=>Int32), select=["first"])`. During parsing, it knew we
 would drop the `id` column, so it parsed it as `Missing`, but then
 tried to "set" the value to a `Vector{Int32}` which threw an error.
 When dropping a column, we can basically ignore any provided type
 information instead, so in the `Header` routine, we make sure to mark
 the type of a column as `Missing` if it will be dropped.