### PR TITLE
Change deprecation warning for CSV.read

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -30,18 +30,19 @@ include("rows.jl")
 include("write.jl")
 
 """
-`CSV.read(source; copycols::Bool=false, kwargs...)` => `DataFrame`
+`CSV.read(source, sink::T; kwargs...)` => T
 
-Parses a delimited file into a `DataFrame`. `copycols` determines whether a copy of columns should be made when creating the DataFrame; by default, no copy is made.
+Read and parses a delimited file, materializing directly using the `sink` function.
 
-`CSV.read` supports the same keyword arguments as [`CSV.File`](@ref).
+`CSV.read` supports all the same keyword arguments as [`CSV.File`](@ref).
 """
-function read(source; copycols::Bool=false, kwargs...)
-    @warn "`CSV.read(input; kw...)` is deprecated in favor of `DataFrame!(CSV.File(input; kw...))`"
-    DataFrame(CSV.File(source; kwargs...), copycols=copycols)
+function read(source, sink=nothing; copycols::Bool=false, kwargs...)
+    if sink === nothing
+        @warn "`CSV.read(input; kw...)` is deprecated in favor of `CSV.read(input, DataFrame; kw...)"
+        sink = DataFrame
+    end
+    Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink
 end
-
-DataFrames.DataFrame(f::CSV.File; copycols::Bool=true) = DataFrame(getcolumns(f), getnames(f); copycols=copycols)
 
 include("precompile.jl")
 _precompile_()


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2309. After much
discussion, people really like the `CSV.read` function call naming, so
it was decided to keep it around, while still allowing a break from
DataFrames.jl as a dependency.

I also realized that `CSV.read` does indeed provide one bit of
value/functionality: we can wrap `CSV.File` in `Tables.CopiedColumns`.
What this means is that columnar sinks can safely use the columns passed
without needing to make copies; i.e. they can assume ownership of the
columns. In `CSV.read`, the user is essentially saying, "I want to make
a `CSV.File` and pass it directly to `sink`" which also implies that
`CSV.File` doesn't need to "own" its own columns.

The only question left in my mind is, with the 1.0 release, what to do
with `CSV.read(file)` when no `sink` argument is passed. Suggestions
have included just returning a `CSV.File`, since it's a valid table
anyway. Or allowing DataFrames.jl to define the no-sink-arg version and
return a `DataFrame`; that one's a bit awkward as a form of "blessed"
type piracy, but could also be useful for users as convenience (they
just have to remember to do `using DataFrames` before trying to use it).
The other awkward part is that we're currently warning users of the
deprecation and that they should explicitly spell out `DataFrame`
whereas we might not actually require that.