### PR TITLE
Sample column types when finding multithreaded row chunks

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -76,7 +76,7 @@ function Chunks(source;
     chunksize = div(len - datapos, N)
     ranges = [i == 0 ? datapos : (datapos + chunksize * i) for i = 0:N]
     ranges[end] = len
-    findrowstarts!(buf, len, options, ranges, ncols)
+    findrowstarts!(buf, len, options, ranges, ncols, h.types, h.flags)
     return Chunks(h, threaded, typemap, tasks, debug, ranges)
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -396,7 +396,7 @@ f = CSV.File(IOBuffer("x\r\n1\r\n2\r\n3\r\n4\r\n5\r\n"), footerskip=3)
 @test f[1][1] == 1
 
 # 578
-f = CSV.File(IOBuffer("h1234567890123456\t"^2262 * "lasthdr\r\n" *"dummy dummy dummy\r\n"* ("1.23\t"^2262 * "2.46\r\n")^10), datarow=3)
+f = CSV.File(IOBuffer("h1234567890123456\t"^2262 * "lasthdr\r\n" *"dummy dummy dummy\r\n"* ("1.23\t"^2262 * "2.46\r\n")^10), datarow=3, threaded=false)
 @test (length(f), length(f.names)) == (10, 2263)
 @test all(x -> eltype(x) == Float64, f.columns)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,22 +191,22 @@ end
 
 rngs = [1, 1, 1]
 buf = b"normal cell,next cell\nnormal cell2,next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
-CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2)
+CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 23
 
 rngs = [1, 1, 1]
 buf = b"quoted, cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
-CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2)
+CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 25
 
 rngs = [1, 2, 1]
 buf = b"\"\"quoted, cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
-CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2)
+CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 27
 
 rngs = [1, 2, 1]
 buf = b"quoted,\"\" cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
-CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2)
+CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 27
 
 end


### PR DESCRIPTION
This is another optimization I've wanted to do for a while; we're
already checking up to 5 rows from various locations in the file to find
row boundaries for multithreaded parsing, so this just also samples the
types from those locations. The end result is that we already go into
full parsing having checked `tasks * 5` # of rows for column types. The
2 main advantages of adding this are that we can avoid running `detect`
in all tasks in some cases, i.e. if we've already sampled that a column
is `Int64`, then each task will immediately start parsing `Int64`s
instead of having to `detect`, then `allocate`, etc. The other advantage
is if we happen to catch a rogue string value in a part of the file, it
can be promoted immediately instead of having to parse entire chunks as,
say, `Int64`, and then re-parsed later. It's not super robust in that
case because we're only sampling 5 rows from each chunk, but it's better
than nothing and doesn't add extra cost to what we're already doing.

This PR also adds an optimization when a `PooledString` column is
promoted to `String`, we don't need to reparse, but can just allocate
the `String` array and put the ref values in directly according to the
codes.