### PR TITLE
Fix writeheader=false deprecation

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -208,7 +208,7 @@ function write(::Nothing, rows, file, opts;
         return file
     end
     row, st = state
-    names = isempty(header) ? propertynames(row) : header
+    names = header === false || isempty(header) ? propertynames(row) : header
     sch = Tables.Schema(names, nothing)
     cols = length(names)
     with(file, append) do io

--- a/test/write.jl
+++ b/test/write.jl
@@ -316,4 +316,9 @@ const table_types = (
     s = join(1:1000000);
     @test_throws ArgumentError CSV.write("out.test.csv", [(a=s,)])
 
+    # https://github.com/JuliaData/CSV.jl/issues/691
+    io = IOBuffer()
+    CSV.write(io, Tuple[(1,), (2,)], header=false)
+    @test String(take!(io)) == "1\n2\n"
+
 end # @testset "CSV.write"


### PR DESCRIPTION
There was a case where we were still assuming header is always a vector;
this led to a confusing error when passing writeheader=false.