### PR TITLE
deprecation warning when `DataFrames` is not being used

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -38,7 +38,7 @@ Read and parses a delimited file, materializing directly using the `sink` functi
 """
 function read(source, sink=nothing; copycols::Bool=false, kwargs...)
     if sink === nothing
-        @warn "`CSV.read(input; kw...)` is deprecated in favor of `CSV.read(input, CSV.DataFrame; kw...)"
+        @warn "`CSV.read(input; kw...)` is deprecated in favor of `using DataFrames; CSV.read(input, DataFrame; kw...)"
         sink = DataFrame
     end
     Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -38,7 +38,7 @@ Read and parses a delimited file, materializing directly using the `sink` functi
 """
 function read(source, sink=nothing; copycols::Bool=false, kwargs...)
     if sink === nothing
-        @warn "`CSV.read(input; kw...)` is deprecated in favor of `CSV.read(input, DataFrame; kw...)"
+        @warn "`CSV.read(input; kw...)` is deprecated in favor of `CSV.read(input, CSV.DataFrame; kw...)"
         sink = DataFrame
     end
     Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink


### PR DESCRIPTION
If `DataFrames` is not being directly used in the current module, the advice in the deprecation warning does not work. Qualifying it as `CSV.DataFrame` should work in all cases, and it should produce the same result... or not?