### PR TITLE
Use depwarn for deprecations

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -38,7 +38,7 @@ Read and parses a delimited file, materializing directly using the `sink` functi
 """
 function read(source, sink=nothing; copycols::Bool=false, kwargs...)
     if sink === nothing
-        @warn "`CSV.read(input; kw...)` is deprecated in favor of `using DataFrames; CSV.read(input, DataFrame; kw...)"
+        Base.depwarn("`CSV.read(input; kw...)` is deprecated in favor of `using DataFrames; CSV.read(input, DataFrame; kw...)", :read)
         sink = DataFrame
     end
     Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink

--- a/src/header.jl
+++ b/src/header.jl
@@ -95,13 +95,13 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
     checkvaliddelim(delim)
     ignorerepeated && delim === nothing && throw(ArgumentError("auto-delimiter detection not supported when `ignorerepeated=true`; please provide delimiter like `delim=','`"))
     if use_mmap !== nothing
-        @warn "`use_mmap` keyword argument is deprecated and will be removed in the next release"
+        Base.depwarn("`use_mmap` keyword argument is deprecated and will be removed in the next release", :Header)
     end
     if categorical !== nothing
-        @warn "the `categorical` keyword argument is deprecated; in the next release, you'll need to do `using CategoricalArrays; catg = categorical(f.pooled_column)`, where `pooled_column` is the column of a `CSV.File` you want as a `CategoricalArray`"
+        Base.depwarn("The `categorical` keyword argument is deprecated; in the next release, you'll need to do `using CategoricalArrays; catg = categorical(f.pooled_column)`, where `pooled_column` is the column of a `CSV.File` you want as a `CategoricalArray`", :Header)
     end
     if categorical isa Real
-        @warn "categorical=$categorical is deprecated in favor of `pool=$categorical`; categorical is only used to determine CategoricalArray vs. PooledArrays"
+        Base.depwarn("`categorical=$categorical` is deprecated in favor of `pool=$categorical`; categorical is only used to determine CategoricalArray vs. PooledArrays", :Header)
         pool = categorical
         categorical = categorical > 0.0
     elseif categorical === true

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -236,7 +236,7 @@ function getsource(x)
     elseif x isa Base.GenericIOBuffer
         return x.data, x.ptr, x.size
     elseif x isa Cmd || x isa IO
-        @warn "`CSV.File` or `CSV.Rows` with `$(typeof(x))` object is deprecated; pass a filename, `IOBuffer`, or byte buffer directly (via `read(x)`)"
+        Base.depwarn("`CSV.File` or `CSV.Rows` with `$(typeof(x))` object is deprecated; pass a filename, `IOBuffer`, or byte buffer directly (via `read(x)`)", :getsource)
         buf = Base.read(x)
         return buf, 1, length(buf)
     else

--- a/src/write.jl
+++ b/src/write.jl
@@ -148,7 +148,7 @@ function write(file, itr;
     kwargs...)
     checkvaliddelim(delim)
     if writeheader !== nothing
-        @warn "`writeheader=$writeheader` is deprecated in favor of `header=$writeheader`"
+        Base.depwarn("`writeheader=$writeheader` is deprecated in favor of `header=$writeheader`", :write)
         header = writeheader
     else
         header = !append
@@ -294,7 +294,7 @@ end
 
 @noinline nothingerror(col) = error(
     """
-    A `nothing` value was found in column $col and it is not a printable value. 
+    A `nothing` value was found in column $col and it is not a printable value.
     There are several ways to handle this situation:
     1) fix the data, perhaps replace `nothing` with `missing`,
     2) use `transform` option with a funciton to replace `nothing` with whatever value (including `missing`), or

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -298,7 +298,7 @@ f = CSV.File(IOBuffer("x\n2019-01-01\n\n"))
 @test f.x[2] === missing
 
 # use_mmap=false
-f = CSV.File(IOBuffer("x\n2019-01-01\n\n"), use_mmap=false)
+f = @test_deprecated CSV.File(IOBuffer("x\n2019-01-01\n\n"), use_mmap=false)
 @test (length(f), length(f.names)) == (2, 1)
 @test f.x[1] === Date(2019, 1, 1)
 @test f.x[2] === missing
@@ -372,7 +372,8 @@ if Sys.iswindows()
         catcmd = `$busybox cat`
     end
 end
-@test columntable(CSV.File(`$(catcmd) $(joinpath(dir, "test_basic.csv"))`)) == columntable(CSV.File(joinpath(dir, "test_basic.csv")))
+f = @test_deprecated CSV.File(`$(catcmd) $(joinpath(dir, "test_basic.csv"))`)
+@test columntable(f) == columntable(CSV.File(joinpath(dir, "test_basic.csv")))
 
 #476
 f = CSV.File(transcode(GzipDecompressor, Mmap.mmap(joinpath(dir, "randoms.csv.gz"))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,12 +28,12 @@ include("write.jl")
     @test v == "b"
     @test levels(v.pool) == ["a", "b", "c"]
 
-    f = CSV.File(IOBuffer("X\nb\nc\na\nc"), categorical=true)
+    f = @test_deprecated CSV.File(IOBuffer("X\nb\nc\na\nc"), categorical=true)
     v = f.X[1]
     @test v == "b"
     @test levels(v.pool) == ["a", "b", "c"]
 
-    f = CSV.File(IOBuffer("X\nb\nc\n\nc"), categorical=true)
+    f = @test_deprecated CSV.File(IOBuffer("X\nb\nc\n\nc"), categorical=true)
     v = f.X[1]
     @test v == "b"
     @test levels(v.pool) == ["b", "c"]

--- a/test/write.jl
+++ b/test/write.jl
@@ -174,7 +174,11 @@ const table_types = (
     io = IOBuffer()
     for case in testcases
         global x = case
-        case[1] |> CSV.write(io; case[2]...)
+        if :writeheader in keys(case[2])
+            @test_deprecated case[1] |> CSV.write(io; case[2]...)
+        else
+            case[1] |> CSV.write(io; case[2]...)
+        end
         @test String(take!(io)) == case[3]
         @test join(collect(CSV.RowWriter(case[1]; case[2]...))) == case[3]
     end
@@ -208,7 +212,7 @@ const table_types = (
     # #247
     open(file, "w") do io
         write(io, "or5a2ztZo\n")
-        (A=1:3, B=[17, 17, 19], C=["Wg5", "SJ4", "w48"]) |> CSV.write(io; append=true, writeheader=true)
+        @test_deprecated (A=1:3, B=[17, 17, 19], C=["Wg5", "SJ4", "w48"]) |> CSV.write(io; append=true, writeheader=true)
     end
     @test String(read(file)) == "or5a2ztZo\nA,B,C\n1,17,Wg5\n2,17,SJ4\n3,19,w48\n"
     rm(file)


### PR DESCRIPTION
Changes deprecation warnings to use `Base.depwarn` instead of `@warn`. The primary advantage is that you can use `--depwarn=no` to suppress deprecations or `--depwarn=error` to get a full stack trace. 