### PR TITLE
Fix when column was maybe detected as pooled, then disappeared in data

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -700,6 +700,10 @@ end
                         if columns[j] isa Vector{UInt32}
                             ref = getref!(refs[j], missing, code, options)
                             columns[j][row] = ref
+                            @inbounds flag = flags[j]
+                            if !user(flag) && maybepooled(flag) && row == POOLSAMPLESIZE
+                                resize!(columns[j], rowsguess)
+                            end
                         end
                     end
                     break # from for col = 1:ncols

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -534,4 +534,8 @@ f = CSV.File(IOBuffer("a,b\n1,2"); types = Dict{Symbol,Type}(
 @test f.a[1] == "1"
 @test f.b[1] == "2"
 
+# 726
+f = CSV.File(IOBuffer("col1,col2,col3,col4,col5\na,b,c,d,e\n" * "a,b,c,d\n"^101))
+@test length(f) == 102
+
 end


### PR DESCRIPTION
Fixes #726. The issue here is that we might be trying to detect if a
column should be pooled, which we then sample the 1st 100 rows, but if
the column "goes missing" in the data, i.e. a row doesn't have values
for all the expected columns, including our maybe pooled column, then we
had a separate path that just set the value for that row to `missing`.
But this errored when we tried to set `missing` on our maybe pooled
column after the 1st 100 rows. The fix here is a little dumb, but
simple; if we're dealing w/ a maybe pooled column that's gone missing on
the 100th row, then we'll just resize it up to the full rowsguess. It
still might be promoted to a full string column later if values come
back for that column, which means we'll have wasted some space by
allocating the full pooled column when we didn't need to, but this is a
pretty rare case that it's probably not a big deal in practice (i.e. the
specific scenario where a column is being auto-detected as pooled, the
column goes missing for at least the 100th row of data, then comes back
and there are enough unique values to push us over the pool threshold).