### PR TITLE
Warn if user passes threaded=true, but there aren't enough rows

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -248,6 +248,9 @@ function File(h::Header;
         elseif tasks == 1
             @warn "`threaded=true` but `tasks=1`; to support threaded parsing, pass `tasks=N` where `N > 1`; `tasks` defaults to `Threads.nthreads()`, so you may consider starting Julia with multiple threads"
             threaded = false
+        elseif minrows < (tasks * 5)
+            @warn "`threaded=true` but there were not enough estimated rows ($minrows) to justify multithreaded parsing"
+            threaded = false
         end
     end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -526,6 +526,11 @@ f = CSV.File(transcode(GzipDecompressor, Mmap.mmap(joinpath(dir, "randoms.csv.gz
 @test length(f) == 70000
 @test eltype(f.first) == String
 
+# 723
+f = CSV.File(IOBuffer("col1,col2,col3\n1.0,2.0,3.0\n1.0,2.0,3.0\n1.0,2.0,3.0\n1.0,2.0,3.0\n"); threaded=true)
+@test length(f) == 4
+@test f isa CSV.File{false}
+
 # 706
 f = CSV.File(IOBuffer("a,b\n1,2"); types = Dict{Symbol,Type}(
                :a => CategoricalValue{String,UInt32},


### PR DESCRIPTION
Fixes #723. The issue is that for threaded parsing, we need a minimum of
5 rows per task to correctly check that each threaded chunk starts at a
proper row start position; if we don't have at least 5 rows per task,
then we'll now issue a warning and set `threaded = false`.