### PR TITLE
Add lines_to_check to allow configuring multithreaded parsing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,13 @@ Depth = 3
 ## Getting Started
 
 CSV.jl provides a number of utilities for working with delimited files. `CSV.File` provides a way to read files into columns of data, detecting column types.
-`CSV.Rows` provides a row iterator for looping over rows in a file. Inputs to either should be filenames as `String`s, or byte vectors (`AbstractVector{UInt8}`). To read other `IO` inputs, just call `read(io)` and pass the bytes directly to `CSV.File` or `CSV.Rows`.
+`CSV.Rows` provides a row iterator for looping over rows in a file. Inputs to either should be filenames as `String`s or `FilePath`s, or byte vectors (`AbstractVector{UInt8}`). To read other `IO` inputs, just call `read(io)` and pass the bytes directly to `CSV.File` or `CSV.Rows`.
+
+If `julia` is started with multiple threads (i.e. `julia -t 4`, or with `JULIA_NUM_THREADS` environment variable set), `CSV.File` will use those threads
+by default to parse large enough files. There are a few keyword arguments to control multithreaded parsing, including:
+  * `threaded=false`: turn off multithreaded parsing, the file will be read sequentially using a single thread
+  * `tasks=N`: control how many tasks/chunks are used to break up a file; by default, `Threads.nthreads()` will be used
+  * `lines_to_check=M`: when a file is split into chunks, the parser must then find valid starts/ends to rows; this keyword argument controls how many lines are checked to ensure valid rows are found; for files with very large quoted text fields, it may be required to use a higher number here (10, 30, etc.)
 
 ## Key Functions
 ```@docs

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -41,6 +41,7 @@ function Chunks(source;
     ignoreemptylines::Bool=true,
     threaded::Union{Bool, Nothing}=nothing,
     tasks::Integer=Threads.nthreads(),
+    lines_to_check::Integer=5,
     select=nothing,
     drop=nothing,
     # parsing options
@@ -76,7 +77,7 @@ function Chunks(source;
     chunksize = div(len - datapos, N)
     ranges = [i == 0 ? datapos : (datapos + chunksize * i) for i = 0:N]
     ranges[end] = len
-    findrowstarts!(buf, len, options, ranges, ncols, h.types, h.flags)
+    findrowstarts!(buf, len, options, ranges, ncols, h.types, h.flags, lines_to_check)
     return Chunks(h, threaded, typemap, tasks, debug, ranges)
 end
 

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -306,7 +306,7 @@ end
 # right # of expected columns then we move on to the next file chunk byte position. If we fail, we start over
 # at the byte position, assuming we were in the a quoted field (and encountered a newline inside the quoted
 # field the first time through)
-function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, ranges, ncols, types, flags) where {ignorerepeated}
+function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, ranges, ncols, types, flags, lines_to_check=5) where {ignorerepeated}
     totalbytes = 0
     totalrows = 0
     totalmissing = 0
@@ -329,7 +329,7 @@ function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, rang
             # now we read the next 5 rows and see if we get the right # of columns
             rowstartpos = pos
             correct = true
-            for j = 1:5
+            for j = 1:lines_to_check
                 for col = 1:ncols
                     _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
                     if !typedetected(flags[col])
@@ -353,7 +353,7 @@ function findrowstarts!(buf, len, options::Parsers.Options{ignorerepeated}, rang
             if correct
                 # boom, we read a whole row and got correct # of columns
                 totalbytes += pos - rowstartpos
-                totalrows += 5
+                totalrows += lines_to_check
                 for col = 1:ncols
                     types[col] = detectedtypes[col]
                 end


### PR DESCRIPTION
Fixes #721. When multithreaded parsing, we have to split up a file and
try to find the start of valid rows. By default, we've just been
checking 5 rows to ensure we found the start of a valid row; this PR
allows passing in a custom # of `lines_to_check` in case of problematic
files, usually ones with very large quoted text fields.