### PR TITLE
Check missingstrings for space/tab for setting Parsers Options

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -1,5 +1,9 @@
 module CSV
 
+if !isdefined(Base, :contains)
+    contains(haystack, needle) = occursin(needle, haystack)
+end
+
 # stdlib
 using Mmap, Dates, Unicode
 # Parsers.jl is used for core type parsing from byte buffers

--- a/src/header.jl
+++ b/src/header.jl
@@ -164,6 +164,14 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         # step 3: build Parsers.Options w/ parsing arguments
         wh1 = d == UInt(' ') ? 0x00 : UInt8(' ')
         wh2 = d == UInt8('\t') ? 0x00 : UInt8('\t')
+        for sent in sentinel
+            if contains(sent, " ")
+                wh1 = 0x00
+            end
+            if contains(sent, "\t")
+                wh2 = 0x00
+            end
+        end
         options = Parsers.Options(sentinel, wh1, wh2, oq, cq, eq, d, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, true, parsingdebug, strict, silencewarnings)
 
         # step 4a: if we're ignoring repeated delimiters, then we ignore any

--- a/src/header.jl
+++ b/src/header.jl
@@ -164,12 +164,14 @@ getdf(x::AbstractDict{Int}, nm, i) = haskey(x, i) ? x[i] : nothing
         # step 3: build Parsers.Options w/ parsing arguments
         wh1 = d == UInt(' ') ? 0x00 : UInt8(' ')
         wh2 = d == UInt8('\t') ? 0x00 : UInt8('\t')
-        for sent in sentinel
-            if contains(sent, " ")
-                wh1 = 0x00
-            end
-            if contains(sent, "\t")
-                wh2 = 0x00
+        if sentinel isa Vector
+            for sent in sentinel
+                if contains(sent, " ")
+                    wh1 = 0x00
+                end
+                if contains(sent, "\t")
+                    wh2 = 0x00
+                end
             end
         end
         options = Parsers.Options(sentinel, wh1, wh2, oq, cq, eq, d, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, true, parsingdebug, strict, silencewarnings)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -543,4 +543,9 @@ f = CSV.File(IOBuffer("a,b\n1,2"); types = Dict{Symbol,Type}(
 f = CSV.File(IOBuffer("col1,col2,col3,col4,col5\na,b,c,d,e\n" * "a,b,c,d\n"^101))
 @test length(f) == 102
 
+# 743
+f = CSV.File(IOBuffer("col1\n\n \n  \n1\n2\n3"), missingstrings=["", " ", "  "], ignoreemptylines=false)
+@test length(f) == 6
+@test isequal(f.col1, [missing, missing, missing, 1, 2, 3])
+
 end


### PR DESCRIPTION
Fixes #743. In this issue, Parsers.jl was correctly validating inputs
and throwing an error because the sentinel values contained whitespace
characters. The fix then, as implemented in this PR, is to check
user-provided missingstrings if they contain space or tab and if so,
disable leading/trailing whitespace trimming.