### PR TITLE
Fallback to singled-threaded parsing if file chunking fails

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -74,7 +74,7 @@ function Chunks(source;
     rowsguess, ncols, buf, len, datapos, options = h.rowsguess, h.cols, h.buf, h.len, h.datapos, h.options
     N = tasks > rowsguess || rowsguess < 100 ? 1 : tasks == 1 ? 8 : tasks
     chunksize = div(len - datapos, N)
-    ranges = [i == 0 ? datapos : i == N ? len : (datapos + chunksize * i) for i = 0:N]
+    ranges = Int64[i == 0 ? datapos : i == N ? len : (datapos + chunksize * i) for i = 0:N]
     findrowstarts!(buf, len, options, ranges, ncols, h.types, h.flags, lines_to_check)
     return Chunks(h, threaded, typemap, tasks, debug, ranges)
 end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -70,13 +70,11 @@ function Chunks(source;
     debug::Bool=false,
     parsingdebug::Bool=false)
 
-    limit=typemax(Int64)
     h = Header(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, use_mmap, ignoreemptylines, select, drop, missingstrings, missingstring, delim, ignorerepeated, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, categorical, pool, lazystrings, strict, silencewarnings, debug, parsingdebug, false)
     rowsguess, ncols, buf, len, datapos, options = h.rowsguess, h.cols, h.buf, h.len, h.datapos, h.options
     N = tasks > rowsguess || rowsguess < 100 ? 1 : tasks == 1 ? 8 : tasks
     chunksize = div(len - datapos, N)
-    ranges = [i == 0 ? datapos : (datapos + chunksize * i) for i = 0:N]
-    ranges[end] = len
+    ranges = [i == 0 ? datapos : i == N ? len : (datapos + chunksize * i) for i = 0:N]
     findrowstarts!(buf, len, options, ranges, ncols, h.types, h.flags, lines_to_check)
     return Chunks(h, threaded, typemap, tasks, debug, ranges)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,23 +189,23 @@ end
 
 @testset "CSV.findrowstarts!" begin
 
-rngs = [1, 1, 1]
 buf = b"normal cell,next cell\nnormal cell2,next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
+rngs = [1, 1, length(buf)]
 CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 23
 
-rngs = [1, 1, 1]
 buf = b"quoted, cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
+rngs = [1, 1, length(buf)]
 CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 25
 
-rngs = [1, 2, 1]
 buf = b"\"\"quoted, cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
+rngs = [1, 2, length(buf)]
 CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 27
 
-rngs = [1, 2, 1]
 buf = b"quoted,\"\" cell\",next cell\n\"normal cell2\",next cell2\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho\nhey,ho"
+rngs = [1, 2, length(buf)]
 CSV.findrowstarts!(buf, length(buf), CSV.Parsers.XOPTIONS, rngs, 2, [Union{}, Union{}], [0x00, 0x00])
 @test rngs[2] == 27
 


### PR DESCRIPTION
Provides a better experience for cases like #727. On current master, if
there's a mismatch between the number of columns detected in the header
vs. in the rest of the file, the multithreaded chunking operation fails
because it can't accurately detect the right # of columns to be
expected. Also on current master, in this scenario, we throw an error,
which isn't a great user experience since they usually didn't ask
explicitly for threaded parsing anyway. The change in this PR is that if
we fail to determine accurate chunks for multithreaded parsing, then
we'll just fallback to parsing the entire file single-threaded, which
allows full parsing with no errors, though warnings may be emitted.