### PR TITLE
Allow multithreaded writing of input table partitions

### DIFF
--- a/test/write.jl
+++ b/test/write.jl
@@ -329,4 +329,12 @@ const table_types = (
     CSV.write(io, Tuple[(1,), (2,)], header=false)
     @test String(take!(io)) == "1\n2\n"
 
+    # parition writing
+    io = IOBuffer()
+    io2 = IOBuffer()
+    CSV.write([io, io2], Tables.partitioner((default_table, default_table)); partition=true)
+    @test String(take!(io)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"
+    @test String(take!(io2)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"
+
+
 end # @testset "CSV.write"


### PR DESCRIPTION
Allows passing `CSV.write(file, table; partition=true)`, which will
result in a thread per input partition writing out the csv data; if
`file` is a single file, it will be appended with the index of the
parition being written; users can also pass an indexable collection of
filenames or `IO` arguments that will be paired with the input table
partitions.