### PR TITLE
Improve error message for CSV.read(source)

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -40,7 +40,7 @@ Read and parses a delimited file, materializing directly using the `sink` functi
 """
 function read(source, sink=nothing; copycols::Bool=false, kwargs...)
     if sink === nothing
-        throw(ArgumentError("provide a valid sink argument, like `CSV.read(source, DataFrame)`"))
+        throw(ArgumentError("provide a valid sink argument, like `using DataFrames; CSV.read(source, DataFrame)`"))
     end
     Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink
 end


### PR DESCRIPTION
Cf. https://discourse.julialang.org/t/csv-read-error-provide-a-valid-sink-argument/50157/6.