### PR TITLE
Avoid ambiguity between user-provided UInt64 column type and PosLen

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -545,4 +545,11 @@ f = CSV.File(codeunits("a\n1"))
 @test length(f) == 1
 @test f.a == [1]
 
+# 785
+csv = """1,1,1,1,1,1
+2,2,2,2,2,2
+3,3,3,3,3,3"""
+f = CSV.File(IOBuffer(csv); header=0, types=[UInt64,Int64,UInt128,Int128,UInt32,Int32])
+@test eltype(f.Column1) == UInt64
+
 end


### PR DESCRIPTION
Fixes #785. The issue here is that we were overloading `allocate(T,
len)` for various types, including our custom `PosLen` type when strings
are just parsed as a position and length. The problem is `PosLen` is
defined as `const PosLen = UInt64`, which means for a user-provided
`UInt64` type, it was allocating a plain `Vector{UInt64}` instead of the
expected `SentinelVector{UInt64}`. We were already special-casing the
allocation of the `PosLen` column, so the fix is pretty easy; create a
new `allocateposlen` instead of relying on the `allocate` overload.