### PR TITLE
Avoid ambiguity between user-provided UInt64 column type and PosLen

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,11 +94,13 @@ end
 
 ## lazy strings
 # bit patterns for missing value, int value, escaped string, position and len in lazy string parsing
-const PosLen = UInt64
 
-# primitive type PosLen 64 end
-# PosLen(x::UInt64) = Core.bitcast(PosLen, x)
-# UInt64(x::PosLen) = Core.bitcast(UInt64, x)
+primitive type PosLen 64 end
+PosLen(x::UInt64) = Core.bitcast(PosLen, x)
+UInt64(x::PosLen) = Core.bitcast(UInt64, x)
+
+Base.convert(::Type{PosLen}, x::UInt64) = PosLen(x)
+Base.convert(::Type{UInt64}, x::PosLen) = UInt64(x)
 
 const MISSING_BIT = 0x8000000000000000
 missingvalue(x) = (UInt64(x) & MISSING_BIT) == MISSING_BIT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ end
 
     buffer = b"heytheresailoresc\\\"aped"
     e = UInt8('\\')
-    poslens = [
+    poslens = CSV.PosLen[
         CSV.poslen(Int16(0), Int64(1), Int64(3)),
         CSV.poslen(Int16(0), Int64(4), Int64(5)),
         CSV.poslen(Int16(0), Int64(9), Int64(6)),
@@ -66,10 +66,10 @@ end
     @test isequal(x, ["hey", "there", "sailor", "esc\"aped", missing])
 
     poslens = ChainedVector([
-        [CSV.poslen(Int16(0), Int64(1), Int64(3))],
-        [CSV.poslen(Int16(0), Int64(4), Int64(5))],
-        [CSV.poslen(Int16(0), Int64(9), Int64(6))],
-        [CSV.poslen(Parsers.ESCAPED_STRING, Int64(15), Int64(8))]
+        CSV.PosLen[CSV.poslen(Int16(0), Int64(1), Int64(3))],
+        CSV.PosLen[CSV.poslen(Int16(0), Int64(4), Int64(5))],
+        CSV.PosLen[CSV.poslen(Int16(0), Int64(9), Int64(6))],
+        CSV.PosLen[CSV.poslen(Parsers.ESCAPED_STRING, Int64(15), Int64(8))]
     ])
     x = CSV.LazyStringVector{String}(buffer, e, poslens)
     @test x == ["hey", "there", "sailor", "esc\"aped"]


### PR DESCRIPTION
Fixes #785 and alternative solution to #786. As opposed to the solution
in that PR, which caused other issues, in this PR, we change from
defining `const PosLen = UInt64` to `primitive type PosLen 64 end` and
define a few helper conversions. This makes `PosLen` its own proper
type, and avoids the dispatch ambiguity of the original issue.