### PR TITLE
Don't consider single space as delimiter in auto-detect fallback

### DIFF
--- a/src/detection.jl
+++ b/src/detection.jl
@@ -128,8 +128,9 @@ function detectdelimandguessrows(buf, headerpos, datapos, len, oq, eq, cq, delim
             end
             if d == UInt8('\n')
                 maxcnt = 0
-                for attempted_delim in (UInt8(','), UInt8('\t'), UInt8(' '), UInt8('|'), UInt8(';'), UInt8(':'))
+                for attempted_delim in (UInt8(','), UInt8('\t'), UInt8('|'), UInt8(';'), UInt8(':'))
                     cnt = headerbvc.counts[Int(attempted_delim)]
+                    # @show Char(attempted_delim), cnt, maxcnt
                     if cnt > maxcnt
                         d = attempted_delim
                         maxcnt = cnt

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -564,4 +564,9 @@ junk
 @test length(f) == 1
 @test f[1].name == 1
 
+# 799
+f = CSV.File(IOBuffer("Created Date\nToday\n"))
+@test length(f) == length(f.names)
+@test f[1][Symbol("Created Date")] == "Today"
+
 end


### PR DESCRIPTION
Resolves #799. As noted in that issue, the problem for the OP is in the
auto delimiter detection code, if a delimiter can't be detected that has
an equal # of instances on the rows parsed, it considers the header row
and the most common delimiter detected there. The change in this PR is
to NOT consider a single space `' '` as a valid delimiter in that case
since it's far too common for column names to have spaces, so it's just
throwing off the attempt at detecting a delimiter.