### PR TITLE
Fix CSV.File schema for pooled columns when multithreaded parsing

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -515,6 +515,7 @@ end # @static if VERSION >= v"1.3-DEV"
             elseif column isa Vector{UInt32}
                 chain = makechain(Vector{UInt32}, column, N, col, pertaskcolumns, limit, anymissing(flags[col]))
                 makeandsetpooled!(finalcolumns, col, chain, refs, flags)
+                types[col] = anymissing(flags[col]) ? Union{String, Missing} : String
             elseif column isa Vector{PosLen}
                 chain = makechain(Vector{PosLen}, column, N, col, pertaskcolumns, limit, anymissing(flags[col]))
                 if anymissing(flags[col])

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -588,6 +588,9 @@ f = CSV.File(IOBuffer(csv); skipto=1, footerskip=1)
 f = CSV.File(IOBuffer(csv); skipto=1, footerskip=2)
 @test length(f) == 3
 
-f = CSV.File(IOBuffer(join(rand(("a", "b", "c"), 500), "\n")); header=false, threaded=true)
+f = CSV.File(IOBuffer(join(rand(["a", "b", "c"], 500), "\n")); header=false, threaded=true)
+rt = Tables.rowtable(f)
+@test length(rt) == 500
+@test eltype(rt) == NamedTuple{(:Column1,), Tuple{String}}
 
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -588,4 +588,6 @@ f = CSV.File(IOBuffer(csv); skipto=1, footerskip=1)
 f = CSV.File(IOBuffer(csv); skipto=1, footerskip=2)
 @test length(f) == 3
 
+f = CSV.File(IOBuffer(join(rand(("a", "b", "c"), 500), "\n")); header=false, threaded=true)
+
 end


### PR DESCRIPTION
Fixes #827. The issue here is the column type of pooled columns was
still `PooledString` when finished parsing, which is an internal-only
type used while parsing to signal a column is being pooled. The fix is
pretty straightforward: ensure the column type is `String` or
`Union{String, Missing}` when we're done parsing.