### PR TITLE
Fix ByteValueCounter out of bounds indexing

### DIFF
--- a/src/detection.jl
+++ b/src/detection.jl
@@ -119,7 +119,7 @@ function detectdelimandguessrows(buf, headerpos, datapos, len, oq, eq, cq, delim
         if nlines > 0
             d = UInt8('\n')
             for attempted_delim in (UInt8(','), UInt8('\t'), UInt8(' '), UInt8('|'), UInt8(';'), UInt8(':'))
-                cnt = bvc.counts[Int(attempted_delim)]
+                cnt = bvc.counts[Int(attempted_delim) + 1]
                 # @show Char(attempted_delim), cnt, nlines
                 if cnt > 0 && cnt % nlines == 0
                     d = attempted_delim
@@ -129,7 +129,7 @@ function detectdelimandguessrows(buf, headerpos, datapos, len, oq, eq, cq, delim
             if d == UInt8('\n')
                 maxcnt = 0
                 for attempted_delim in (UInt8(','), UInt8('\t'), UInt8('|'), UInt8(';'), UInt8(':'))
-                    cnt = headerbvc.counts[Int(attempted_delim)]
+                    cnt = headerbvc.counts[Int(attempted_delim) + 1]
                     # @show Char(attempted_delim), cnt, maxcnt
                     if cnt > maxcnt
                         d = attempted_delim
@@ -157,7 +157,7 @@ struct ByteValueCounter
 end
 
 function incr!(c::ByteValueCounter, b::UInt8)
-    @inbounds c.counts[b] += 1
+    @inbounds c.counts[b + 1] += 1
     return
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -627,4 +627,9 @@ f = CSV.File(IOBuffer("a, 0.1, 0.2, 0.3\nb, 0.4"); transpose=true)
 @test f.a == [0.1, 0.2, 0.3]
 @test isequal(f.b, [0.4, missing, missing])
 
+# 845
+f = CSV.File(IOBuffer("x\n\0\n"))
+@test length(f) == 1
+@test f.x[1] == "\0"
+
 end


### PR DESCRIPTION
Fixes #845. The issue here is we were incrementing the ByteValueCounter
counts vector using the byte value itself, which obviously was out of
bounds for the null character `'\0'`. The solution is pretty simple:
just increment the indexing to ensure we're always inbounds.