### PR TITLE
Use sch.names to get schema names instead of relying on type parameter

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -194,12 +194,12 @@ function write(file, itr;
     end
 end
 
-function write(sch::Tables.Schema{names}, rows, file, opts;
+function write(sch::Tables.Schema, rows, file, opts;
         append::Bool=false,
         header::Union{Bool, Vector}=String[],
         bufsize::Int=2^22
-    ) where {names}
-    colnames = !(header isa Vector) || isempty(header) ? names : header
+    )
+    colnames = !(header isa Vector) || isempty(header) ? sch.names : header
     cols = length(colnames)
     len = bufsize
     buf = Vector{UInt8}(undef, len)


### PR DESCRIPTION
Along with Tables.jl and DataFrames.jl fixes, this provides the CSV.jl
part of fixing #635. I was pleasantly surprised to find this was all
that was needed to support extremely wide tables when writing (reading
already works fine).