### PR TITLE
Update CSV to support Parsers 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,11 +15,11 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 FilePathsBase = "0.6,0.7,0.8,0.9"
-Parsers = "1,2"
+Parsers = "2"
 PooledArrays = "0.5, 1.0"
 SentinelArrays = "1.2"
 Tables = "1.1"
-WeakRefStrings = "0.5,0.6,1"
+WeakRefStrings = "1.2"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 FilePathsBase = "0.6,0.7,0.8,0.9"
-Parsers = "1"
+Parsers = "1,2"
 PooledArrays = "0.5, 1.0"
 SentinelArrays = "1.2"
 Tables = "1.1"

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -17,7 +17,7 @@ using PooledArrays
 # it also provides the MissingVector and ChainedVector array types
 using SentinelArrays
 using WeakRefStrings
-export PosLenString
+export PosLenString, InlineString
 
 struct Error <: Exception
     msg::String

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -93,7 +93,7 @@ function Base.iterate(x::Chunks, i=1)
     threaded = false
     ntasks = 1
     limit = typemax(Int64)
-    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, x.ctx.coloptions, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.maxwarnings, x.ctx.debug, x.ctx.streaming)
+    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.streaming)
     f = File(ctx, true)
     return f, i + 1
 end

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -251,7 +251,7 @@ function columnname(buf, poslen, code, options, i)
     if Parsers.sentinel(code) || poslen.len == 0
         return "Column$i"
     elseif Parsers.escapedstring(code)
-        return String(buf, poslen, options.e)
+        return Parsers.getstring(buf, poslen, options.e)
     else
         return unsafe_string(pointer(buf, poslen.pos), poslen.len)
     end

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -161,8 +161,6 @@ function incr!(c::ByteValueCounter, b::UInt8)
     return
 end
 
-ignoreemptyrows(opts::Parsers.Options{ir, iel}) where {ir, iel} = iel
-
 # given the various header and normalization options, figure out column names for a file
 function detectcolumnnames(buf, headerpos, datapos, len, options, header, normalizenames)
     if header isa Union{AbstractVector{Symbol}, AbstractVector{String}}
@@ -178,7 +176,7 @@ function detectcolumnnames(buf, headerpos, datapos, len, options, header, normal
     elseif header isa AbstractVector{<:Integer}
         names, pos = readsplitline(buf, headerpos, len, options)
         for row = 2:length(header)
-            pos = skiptorow(buf, pos, len, options.oq, options.e, options.cq, options.cmt, ignoreemptyrows(options), 1, header[row] - header[row - 1])
+            pos = skiptorow(buf, pos, len, options.oq, options.e, options.cq, options.cmt, options.ignoreemptylines, 1, header[row] - header[row - 1])
             fields, pos = readsplitline(buf, pos, len, options)
             for (i, x) in enumerate(fields)
                 names[i] *= "_" * x
@@ -232,29 +230,30 @@ function skiptorow(buf, pos, len, oq, eq, cq, cmt, ignoreemptyrows, cur, dest)
 end
 
 # read a single row, splitting cells on delimiters; used for parsing column names from header row(s)
-function readsplitline(buf, pos, len, options::Parsers.Options{ignorerepeated}) where {ignorerepeated}
+function readsplitline(buf, pos, len, options::Parsers.Options)
     vals = String[]
     (pos > len || pos == 0) && return vals, pos
     col = 1
     while true
-        _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
-        push!(vals, columnname(buf, vpos, vlen, code, options, col))
-        pos += tlen
+        res = Parsers.xparse(String, buf, pos, len, options)
+        code = res.code
+        push!(vals, columnname(buf, res.val, code, options, col))
+        pos += res.tlen
         col += 1
-        ignorerepeated && Parsers.newline(code) && break
+        options.ignorerepeated && Parsers.newline(code) && break
         Parsers.delimited(code) && continue
         (Parsers.newline(code) || pos > len) && break
     end
     return vals, pos
 end
 
-function columnname(buf, vpos, vlen, code, options, i)
-    if Parsers.sentinel(code) || vlen == 0
+function columnname(buf, poslen, code, options, i)
+    if Parsers.sentinel(code) || poslen.len == 0
         return "Column$i"
     elseif Parsers.escapedstring(code)
-        return String(buf, PosLen(vpos, vlen, false, true), options.e)
+        return String(buf, poslen, options.e)
     else
-        return unsafe_string(pointer(buf, vpos), vlen)
+        return unsafe_string(pointer(buf, poslen.pos), poslen.len)
     end
 end
 
@@ -309,182 +308,208 @@ function checkcommentandemptyline(buf, pos, len, cmt, ignoreemptyrows, nlines=NL
     return pos
 end
 
+struct ColumnProperties
+    typecode::UInt8
+    maxstringsize::UInt8
+end
+ColumnProperties(T) = ColumnProperties(T, 0x00)
+
+@inline function (cp::ColumnProperties)(_, _, _, S::UInt8)
+    T = cp.typecode
+    if T === S
+        return cp
+    elseif T === NEEDSTYPEDETECTION
+        return ColumnProperties(S, cp.maxstringsize)
+    elseif S === NEEDSTYPEDETECTION
+        return cp
+    elseif T === MISSING
+        return ColumnProperties(S, cp.maxstringsize)
+    elseif S === MISSING
+        return cp
+    elseif isinttypecode(T) && isinttypecode(S)
+        return ColumnProperties(promote_typecode(T, S), cp.maxstringsize)
+    elseif isinttypecode(T) && S === FLOAT64
+        return ColumnProperties(S, cp.maxstringsize)
+    elseif T === FLOAT64 && isinttypecode(S)
+        return cp
+    else
+        return ColumnProperties(STRING, cp.maxstringsize)
+    end
+end
+
+function findchunkrowstart(ranges, i, buf, opts, downcast, ncols, rows_to_check, columns, columnlock, stringtype, totalbytes, totalrows, succeeded)
+    pos = ranges[i]
+    len = ranges[i + 1]
+    while pos <= len
+        startpos = pos
+        code = Parsers.ReturnCode(0)
+        attempted_quoted = false
+@label findnextnewline
+        # assume not in quoted field; start parsing, count ncols + newline and if things match, return
+        while pos <= len
+            res = Parsers.xparse(String, buf, pos, len, opts)
+            pos += res.tlen
+            if Parsers.newline(res.code)
+                # assume we found the correct start of the next row
+                ranges[i] = pos
+                break
+            end
+        end
+        # now we read the next `rows_to_check` rows and see if we get the roughly the right # of columns
+        rowstartpos = pos
+        parsedncols = rowsparsed = 0
+        columnprops = Vector{ColumnProperties}(undef, ncols)
+        for i = 1:ncols
+            if columns[i].type === NeedsTypeDetection
+                columnprops[i] = ColumnProperties(typecode(columns[i].type))
+            else
+                columnprops[i] = ColumnProperties(0x00)
+            end
+        end
+        for _ = 1:rows_to_check
+            n = 1
+            while pos <= len
+                res = Parsers.xparse(String, buf, pos, len, opts)
+                poslen, code, tlen = res.val, res.code, res.tlen
+                vpos, vlen = poslen.pos, poslen.len
+                if n <= ncols && !Parsers.sentinel(code)
+                    cp = columnprops[n]
+                    if cp.typecode > 0x00
+                        plen = unsafe_trunc(UInt8, poslen.len)
+                        if plen > cp.maxstringsize
+                            columnprops[n] = cp = ColumnProperties(cp.typecode, plen)
+                        end
+                        cp2 = detect(cp, buf, vpos, vpos + vlen - 1, opts, true, downcast)
+                        if cp != cp2
+                            columnprops[n] = cp2
+                        end
+                    end
+                end
+                pos += tlen
+                if Parsers.newline(code)
+                    rowsparsed += 1
+                    break
+                end
+                n += 1
+                parsedncols += 1
+            end
+        end
+        lock(columnlock) do
+            for i = 1:ncols
+                cp = columnprops[i]
+                col = columns[i]
+                if cp.typecode > 0x00
+                    type = something(promote_types(col.type, something(TYPES[cp.typecode], stringtype)), stringtype)
+                    if type === stringtype
+                        type = pickstringtype(stringtype, cp.maxstringsize)
+                    end
+                    col.type = type
+                end
+            end
+        end
+        f40 = ncols * 0.4
+        if (ncols - f40) <= (parsedncols / rowsparsed) <= (ncols + f40)
+            # ok, seems like we figured out the right start for parsing on this chunk
+            Threads.atomic_add!(totalbytes, pos - rowstartpos)
+            Threads.atomic_add!(totalrows, rows_to_check)
+            break
+        end
+        if attempted_quoted
+            # wah, wah, waaaah. we tried starting outside a quoted field
+            # we started assuming we were _inside_, but can't seem to parse
+            # anything that matches roughly what we're expecting, bail on
+            # multithreaded parsing
+            succeeded[] = false
+            break
+        end
+        # else, assume we were inside a quoted field:
+        pos = startpos
+        # if first byte is quotechar, need to check previous char for escapechar and if so, skip forward
+        if buf[pos] == opts.cq && buf[pos - 1] == opts.e
+            pos += 1
+        end
+        # start parsing until we find quotechar (ignoring escaped quote chars)
+        cq, eq = opts.cq, opts.e
+        while pos <= len
+            b = buf[pos]
+            pos += 1
+            if b == eq
+                if pos > len
+                    break
+                elseif eq == cq && buf[pos] != cq
+                    break
+                end
+                b = buf[pos]
+                pos += 1
+            elseif b == cq
+                break
+            end
+        end
+        # ok, we made it out of a quoted field
+        attempted_quoted = true
+        @goto findnextnewline
+    end
+end
+
 # here we try to "chunk" up a file; given the equally spaced out byte positions in `ranges`, we start at each
 # byte position and start parsing until we find the start of the next row; if the next rows all verify w/ the
 # right # of expected columns then we move on to the next file chunk byte position. If we fail, we start over
 # at the byte position, assuming we were in a quoted field (and encountered a newline inside the quoted
 # field the first time through)
-function findrowstarts!(buf, opts, ranges, ncols, columns, stringtype, pool, downcast, rows_to_check=5)
+function findrowstarts!(buf, opts, ranges, ncols, columns, stringtype, downcast, rows_to_check=5)
     totalbytes = Threads.Atomic{Int}(0)
     totalrows = Threads.Atomic{Int}(0)
     succeeded = Threads.Atomic{Bool}(true)
-    M = rows_to_check * (length(ranges) - 2)
-    samples = Matrix{Any}(undef, M, ncols)
+    N = length(ranges) - 2
+    lock = ReentrantLock()
     @sync for i = 2:(length(ranges) - 1)
         Threads.@spawn begin
-            pos = ranges[i]
-            len = ranges[i + 1]
-            while pos <= len
-                startpos = pos
-                code = Parsers.ReturnCode(0)
-                attempted_quoted = false
-@label findnextnewline
-                # assume not in quoted field; start parsing, count ncols + newline and if things match, return
-                while pos <= len
-                    _, code, _, _, tlen = Parsers.xparse(String, buf, pos, len, opts)
-                    pos += tlen
-                    if Parsers.newline(code)
-                        # assume we found the correct start of the next row
-                        ranges[i] = pos
-                        break
-                    end
-                end
-                # now we read the next `rows_to_check` rows and see if we get the roughly the right # of columns
-                rowstartpos = pos
-                parsedncols = rowsparsed = 0
-                for j = 1:rows_to_check
-                    m = (i - 2) * rows_to_check
-                    n = 1
-                    while pos <= len
-                        _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, opts)
-                        if n <= ncols
-                            col = columns[n]
-                            T = col.type
-                            if T === NeedsTypeDetection
-                                x, _, _ = detect(buf, vpos, vpos + vlen - 1, opts, true, downcast)
-                                samples[m + j, n] = x !== nothing ? x : PosLenString(buf, PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code)), opts.e)
-                            elseif pooled(col) || maybepooled(col)
-                                # if the user provided a column type, we'll trust/respect that
-                                # but if it's also going to be pooled, we might as well try to
-                                # build up a decent refpool during sampling to provide the individual
-                                # parsing tasks so they hopefully stay in sync as much as possible
-                                T = col.type
-                                y, _code, _vpos, _vlen, _tlen = Parsers.xparse(T, buf, vpos, vpos + vlen - 1, opts)
-                                if Parsers.sentinel(_code)
-                                    samples[m + j, n] = missing
-                                elseif T === String || T === PosLenString
-                                    samples[m + j, n] = T(buf, PosLen(vpos, vlen, Parsers.sentinel(_code), Parsers.escapedstring(_code)), opts.e)
-                                else
-                                    samples[m + j, n] = y
-                                end
-                            end
-                        end
-                        pos += tlen
-                        if Parsers.newline(code)
-                            rowsparsed += 1
-                            break
-                        end
-                        n += 1
-                        parsedncols += 1
-                    end
-                end
-                f40 = ncols * 0.4
-                if (ncols - f40) <= (parsedncols / rowsparsed) <= (ncols + f40)
-                    # ok, seems like we figured out the right start for parsing on this chunk
-                    Threads.atomic_add!(totalbytes, pos - rowstartpos)
-                    Threads.atomic_add!(totalrows, rows_to_check)
-                    break
-                end
-                if attempted_quoted
-                    # wah, wah, waaaah. we tried starting outside a quoted field
-                    # we started assuming we were _inside_, but can't seem to parse
-                    # anything that matches roughly what we're expecting, bail on
-                    # multithreaded parsing
-                    succeeded[] = false
-                    break
-                end
-                # else, assume we were inside a quoted field:
-                pos = startpos
-                # if first byte is quotechar, need to check previous char for escapechar and if so, skip forward
-                if buf[pos] == opts.cq && buf[pos - 1] == opts.e
-                    pos += 1
-                end
-                # start parsing until we find quotechar (ignoring escaped quote chars)
-                cq, eq = opts.cq, opts.e
-                while pos <= len
-                    b = buf[pos]
-                    pos += 1
-                    if b == eq
-                        if pos > len
-                            break
-                        elseif eq == cq && buf[pos] != cq
-                            break
-                        end
-                        b = buf[pos]
-                        pos += 1
-                    elseif b == cq
-                        break
-                    end
-                end
-                # ok, we made it out of a quoted field
-                attempted_quoted = true
-                @goto findnextnewline
-            end
+            findchunkrowstart(ranges, i, buf, opts, downcast, ncols, rows_to_check, columns, lock, stringtype, totalbytes, totalrows, succeeded)
         end
     end
     finalrows = totalrows[]
     !succeeded[] && return totalbytes[] / finalrows, false
     # alright, we successfully identified the starting byte positions for each chunk
     # now let's take a look at our samples we parsed, and juice up our column types/flags
-    for n = 1:ncols
-        col = columns[n]
-        type = col.type
-        mss = 0
-        # scan through sampled values
-        for m = 1:M
-            if isassigned(samples, m, n)
-                # we really only care about cases where we sampled something, which is when
-                # a column type was originally NeedsTypeDetection or userprovidedtype && pooled or maybepooled
-                val = samples[m, n]
-                if val === missing
-                    col.anymissing = true
-                elseif val isa PosLenString
-                    mss = max(mss, ncodeunits(val))
-                    type = stringtype
-                else
-                    type = something(promote_types(type, typeof(val)), stringtype)
-                end
-            end
-        end
-        if type === stringtype
-            type = pickstringtype(type, mss)
-        end
-        # build up a refpool of initial values if applicable
-        # if not, or cardinality is too high, we'll set the column to non-pooled at this stage
-        if type === NeedsTypeDetection
-            # if the type is still NeedsTypeDetection, that means we only sampled `missing` values
-            # in that case, the type will stay NeedsTypeDetection and may be detected while parsing
-            # by individual chunks over the whole file
-            # as for pooling, we'll only pool in this case if user explicitly asked for pooling
-            # so maybepooled(col) or isnan(col.pool) won't turn into PooledArray for multithreading
-            # unless we sample something other than `missing` during this stage
-            if !pooled(col)
-                col.pool = 0.0
-            end
-        else
-            if (pooled(col) || maybepooled(col) || (type isa StringTypes && pool != 0.0))
-                refpool = RefPool(type)
-                for m = 1:M
-                    if isassigned(samples, m, n)
-                        val = samples[m, n]
-                        if val isa type || (val isa PosLenString && type isa StringTypes)
-                            getref!(refpool, type, val)
-                        end
-                    end
-                end
-                poolval = !isnan(col.pool) ? col.pool : !isnan(pool) ? pool : DEFAULT_POOL
-                if pooled(col) || ((length(refpool.refs) - 1) / finalrows) <= poolval
-                   col.refpool = refpool 
-                   col.pool = 1.0
-                else
-                    col.pool = 0.0
-                end
-            else
-                col.pool = 0.0
-            end
-        end
-        col.type = type
-    end
+    # for n = 1:ncols
+    #     col = columns[n]
+    #     type = col.type
+    #     # build up a refpool of initial values if applicable
+    #     # if not, or cardinality is too high, we'll set the column to non-pooled at this stage
+    #     if type === NeedsTypeDetection
+    #         # if the type is still NeedsTypeDetection, that means we only sampled `missing` values
+    #         # in that case, the type will stay NeedsTypeDetection and may be detected while parsing
+    #         # by individual chunks over the whole file
+    #         # as for pooling, we'll only pool in this case if user explicitly asked for pooling
+    #         # so maybepooled(col) or isnan(col.pool) won't turn into PooledArray for multithreading
+    #         # unless we sample something other than `missing` during this stage
+    #         # if !pooled(col)
+    #         #     col.pool = 0.0
+    #         # end
+    #     else
+    #         # if (pooled(col) || maybepooled(col) || (type isa StringTypes && pool != 0.0))
+    #         #     refpool = RefPool(type)
+    #         #     for m = 1:M
+    #         #         if isassigned(samples, m, n)
+    #         #             val = samples[m, n]
+    #         #             if val isa type || (val isa PosLen && type isa StringTypes)
+    #         #                 getref!(refpool, type, PosLenString(buf, val, opts.e))
+    #         #             end
+    #         #         end
+    #         #     end
+    #         #     poolval = !isnan(col.pool) ? col.pool : !isnan(pool) ? pool : DEFAULT_POOL
+    #         #     if pooled(col) || ((length(refpool.refs) - 1) / finalrows) <= poolval
+    #         #        col.refpool = refpool 
+    #         #        col.pool = 1.0
+    #         #     else
+    #         #         col.pool = 0.0
+    #         #     end
+    #         # else
+    #         #     col.pool = 0.0
+    #         # end
+    #     end
+    #     col.type = type
+    # end
     return totalbytes[] / finalrows, true
 end
 
@@ -493,9 +518,9 @@ function detecttranspose(buf, pos, len, options, header, skipto, normalizenames)
         # skip to header column to read column names
         row, pos = skiptofield!(buf, pos, len, options, 1, header)
         # io now at start of 1st header cell
-        _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
-        columnnames = [columnname(buf, vpos, vlen, code, options, 1)]
-        pos += tlen
+        res = Parsers.xparse(String, buf, pos, len, options)
+        columnnames = [columnname(buf, res.val, res.code, options, 1)]
+        pos += res.tlen
         row, pos = skiptofield!(buf, pos, len, options, header+1, skipto)
         columnpositions = Int64[pos]
         datapos = pos
@@ -507,9 +532,9 @@ function detecttranspose(buf, pos, len, options, header, skipto, normalizenames)
             # skip to header column to read column names
             row, pos = skiptofield!(buf, pos, len, options, 1, header)
             cols += 1
-            _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, options)
-            push!(columnnames, columnname(buf, vpos, vlen, code, options, cols))
-            pos += tlen
+            res = Parsers.xparse(String, buf, pos, len, options)
+            push!(columnnames, columnname(buf, res.val, res.code, options, cols))
+            pos += res.tlen
             row, pos = skiptofield!(buf, pos, len, options, header+1, skipto)
             push!(columnpositions, pos)
             _, pos = countfields(buf, pos, len, options)
@@ -553,9 +578,9 @@ end
 function skiptofield!(buf, pos, len, options, row, header)
     while row < header
         while pos <= len
-            _, code, _, _, tlen = Parsers.xparse(String, buf, pos, len, options)
-            pos += tlen
-            Parsers.delimited(code) && break
+            res = Parsers.xparse(String, buf, pos, len, options)
+            pos += res.tlen
+            Parsers.delimited(res.code) && break
         end
         row += 1
     end
@@ -565,11 +590,11 @@ end
 function countfields(buf, pos, len, options)
     rows = 0
     while pos <= len
-        _, code, _, _, tlen = Parsers.xparse(String, buf, pos, len, options)
-        pos += tlen
+        res = Parsers.xparse(String, buf, pos, len, options)
+        pos += res.tlen
         rows += 1
-        Parsers.delimited(code) && continue
-        (Parsers.newline(code) || pos > len) && break
+        Parsers.delimited(res.code) && continue
+        (Parsers.newline(res.code) || pos > len) && break
     end
     return rows, pos
 end

--- a/src/file.jl
+++ b/src/file.jl
@@ -743,7 +743,7 @@ function detectcell(buf, pos, len, row, rowoffset, i, col, ctx, rowsguess)::Tupl
         val = poslen
     else
         newT = String
-        val = String(buf, poslen, opts.e)
+        val = Parsers.getstring(buf, poslen, opts.e)
     end
 @label done
     # if we're here, that means we found a non-missing value, so we need to update column
@@ -774,7 +774,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
                 if column isa Vector{UInt32}
                     if type === String || type === PosLenString
                         if Parsers.escapedstring(code)
-                            ref = getref!(col.refpool, type, String(buf, res.val, opts.e))
+                            ref = getref!(col.refpool, type, Parsers.getstring(buf, res.val, opts.e))
                         else
                             poslen = res.val
                             ref = getref!(col.refpool, type, PointerString(pointer(buf, poslen.pos), poslen.len), buf, poslen, opts.e)
@@ -784,7 +784,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
                     end
                     @inbounds column[row] = ref
                 elseif type === String
-                    @inbounds (column::SVec2{String})[row] = String(buf, res.val, opts.e)
+                    @inbounds (column::SVec2{String})[row] = Parsers.getstring(buf, res.val, opts.e)
                 elseif type === PosLenString
                     @inbounds (column::Vector{PosLen})[row] = res.val
                 else

--- a/src/file.jl
+++ b/src/file.jl
@@ -186,11 +186,11 @@ function File(source;
     debug::Bool=false,
     parsingdebug::Bool=false
     )
-    # header=1;normalizenames=false;datarow=-1;skipto=nothing;footerskip=0;transpose=false;comment=nothing;ignoreemptyrows=true;
-    # select=nothing;drop=nothing;limit=nothing;threaded=nothing;ntasks=Threads.nthreads();rows_to_check=30;missingstrings=String[];missingstring="";
-    # delim=nothing;ignorerepeated=false;quotechar='"';openquotechar=nothing;closequotechar=nothing;escapechar='"';dateformat=nothing;
+    # header=1;normalizenames=false;datarow=-1;skipto=-1;footerskip=0;transpose=false;comment=nothing;ignoreemptyrows=true;ignoreemptylines=nothing;
+    # select=nothing;drop=nothing;limit=nothing;threaded=nothing;ntasks=Threads.nthreads();tasks=nothing;rows_to_check=30;lines_to_check=nothing;missingstrings=String[];missingstring="";
+    # delim=nothing;ignorerepeated=false;quoted=true;quotechar='"';openquotechar=nothing;closequotechar=nothing;escapechar='"';dateformat=nothing;
     # dateformats=nothing;decimal=UInt8('.');truestrings=nothing;falsestrings=nothing;type=nothing;types=nothing;typemap=Dict{Type,Type}();
-    # pool=DEFAULT_POOL;downcast=false;lazystrings=false;stringtype=String;strict=false;silencewarnings=false;maxwarnings=100;debug=true;parsingdebug=false;
+    # pool=CSV.DEFAULT_POOL;downcast=false;lazystrings=false;stringtype=String;strict=false;silencewarnings=false;maxwarnings=100;debug=true;parsingdebug=false;
     ctx = Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
     return File(ctx)
 end
@@ -219,7 +219,7 @@ function File(ctx::Context, chunking::Bool=false)
                 task_len = ctx.chunkpositions[i + 1] - (i != ntasks)
                 # for error-reporting purposes, we want to try and give the best guess of where a row emits a warning/error, so compute that
                 rowchunkoffset = (ctx.datarow - 1) + (rowchunkguess * (i - 1))
-                task_rows, task_pos = parsefilechunk!(ctx, ctx.buf, task_pos, task_len, rowchunkguess, rowchunkoffset, task_columns, ctx.transpose, ctx.options, ctx.coloptions, ctx.customtypes)
+                task_rows, task_pos = parsefilechunk!(ctx, ctx.buf, task_pos, task_len, rowchunkguess, rowchunkoffset, task_columns, ctx.transpose, ctx.customtypes)
                 rows[i] = task_rows
                 # promote column types/flags this task detected while parsing
                 lock(wholecolumnslock) do
@@ -263,7 +263,7 @@ function File(ctx::Context, chunking::Bool=false)
             if length(task_columns) < length(columns)
                 # some other task widened columns that this task didn't likewise detect
                 for _ = (length(task_columns) + 1):length(columns)
-                    push!(task_columns, Column(Missing))
+                    push!(task_columns, Column(Missing, ctx.options))
                 end
             end
         end
@@ -281,7 +281,7 @@ function File(ctx::Context, chunking::Bool=false)
                         ctx.debug && println("multithreaded promoting column $j to string from $T2")
                         task_len = ctx.chunkpositions[i + 1] - (i != ntasks)
                         task_pos = ctx.chunkpositions[i]
-                        promotetostring!(ctx, ctx.buf, task_pos, task_len, task_rows, (ctx.datarow - 1) + (rowchunkguess * (i - 1)), task_columns, ctx.transpose, ctx.options, ctx.coloptions, ctx.customtypes, j, Ref(0), task_rows, T)
+                        promotetostring!(ctx, ctx.buf, task_pos, task_len, task_rows, (ctx.datarow - 1) + (rowchunkguess * (i - 1)), task_columns, ctx.transpose, ctx.customtypes, j, Ref(0), task_rows, T)
                     elseif T === Float64 && T2 <: Integer
                         # one chunk parsed as Int, another as Float64, promote to Float64
                         ctx.debug && println("multithreaded promoting column $j to float")
@@ -291,7 +291,7 @@ function File(ctx::Context, chunking::Bool=false)
                             task_col.column = convert(SentinelVector{   Float64}, task_col.column)
                         end
                     elseif T !== T2 && T <: InlineString
-                        if pooled(col)
+                        if task_col.column isa Vector{UInt32}
                             task_col.refpool.refs = convert(Refs{T}, task_col.refpool.refs)
                         else
                             task_col.column = convert(SentinelVector{T}, task_col.column)
@@ -303,7 +303,7 @@ function File(ctx::Context, chunking::Bool=false)
                         task_col.column = allocate(pooled(col) ? Pooled : T, task_rows)
                     end
                     # synchronize refs if needed
-                    if pooled(col)
+                    if pooled(col) || (isnan(col.pool) && col.type isa StringTypes)
                         if !isdefined(col, :refpool) && isdefined(task_col, :refpool)
                             # this case only occurs if user explicitly passed pool=true
                             # but we only parsed `missing` values during sampling
@@ -317,11 +317,24 @@ function File(ctx::Context, chunking::Bool=false)
                         end
                     end
                 end
+@label threadedprocesscolumn
                 if pooled(col)
-                    makechain!(pertaskcolumns, col, j, ntasks)
+                    makechain!(col.type, pertaskcolumns, col, j, ntasks)
                     # pooled columns are the one case where we invert the order of arrays;
                     # i.e. we return PooledArray{T, ChainedVector{T}} instead of ChainedVector{T, PooledArray{T}}
                     makepooled!(col)
+                elseif isnan(col.pool) && col.type isa StringTypes
+                    poolval = !isnan(col.pool) ? col.pool : !isnan(ctx.pool) ? ctx.pool : DEFAULT_POOL
+                    if ((length(col.refpool.refs) - 1) / finalrows) <= poolval
+                        col.pool = 1.0
+                        @goto threadedprocesscolumn
+                    else
+                        # cardinality too high, so unpool
+                        col.pool = 0.0
+                        #!!!!FIXME: need to pass in parent refpool, not pertaskcolumn refpools
+                        foreach(cols -> unpool!(cols[j], col.type, col.refpool), pertaskcolumns)
+                        @goto threadedprocesscolumn
+                    end
                 elseif col.type === Int64
                     # we need to special-case Int64 here because while parsing, a default Int64 sentinel value is chosen to
                     # represent missing; if any chunk bumped into that sentinel value while parsing, then it cycled to a 
@@ -329,14 +342,14 @@ function File(ctx::Context, chunking::Bool=false)
                     # passing force=false means it will first check if all chunks already have the same sentinel and return
                     # immediately if so, which will be the case most often
                     SentinelArrays.newsentinel!((pertaskcolumns[i][j].column::SVec{Int64} for i = 1:ntasks)...; force=false)
-                    makechain!(pertaskcolumns, col, j, ntasks)
+                    makechain!(col.type, pertaskcolumns, col, j, ntasks)
                 elseif col.type === PosLenString
                     col.column = ChainedVector(PosLenStringVector{coltype(col)}[makeposlen!(pertaskcolumns[i][j], coltype(col), ctx) for i = 1:ntasks])
                 elseif col.type === NeedsTypeDetection || col.type === HardMissing
                     col.type = Missing
                     col.column = MissingVector(finalrows)
                 else
-                    makechain!(pertaskcolumns, col, j, ntasks)
+                    makechain!(col.type, pertaskcolumns, col, j, ntasks)
                 end
                 if finalrows < length(col.column)
                     # we only ever resize! down here, so no need to use reallocate!
@@ -349,7 +362,7 @@ function File(ctx::Context, chunking::Bool=false)
         columns = ctx.columns
         allocate!(columns, ctx.rowsguess)
         t = Base.time()
-        finalrows, pos = parsefilechunk!(ctx, ctx.buf, ctx.datapos, ctx.len, ctx.rowsguess, 0, columns, ctx.transpose, ctx.options, ctx.coloptions, ctx.customtypes)
+        finalrows, pos = parsefilechunk!(ctx, ctx.buf, ctx.datapos, ctx.len, ctx.rowsguess, 0, columns, ctx.transpose, ctx.customtypes)
         ctx.debug && println("time for initial parsing: $(Base.time() - t)")
         # cleanup our columns if needed
         for col in columns
@@ -373,7 +386,7 @@ function File(ctx::Context, chunking::Bool=false)
                     makepooled!(col)
                 else
                     # cardinality too high, so unpool
-                    unpool!(col)
+                    unpool!(col, col.type, col.refpool)
                     @goto processcolumn
                 end
             elseif col.type === PosLenString
@@ -462,14 +475,16 @@ function syncrefs!(::Type{T}, col, task_col, task_rows) where {T}
     return
 end
 
-function makechain!(pertaskcolumns, col, j, ntasks)
+function makechain!(::Type{T}, pertaskcolumns, col, j, ntasks) where {T}
     if col.anymissing
         col.column = ChainedVector([pertaskcolumns[i][j].column for i = 1:ntasks])
     else
         if col.type === Bool
-            col.column = ChainedVector([convert(Vector{Bool}, pertaskcolumns[i][j].column) for i = 1:ntasks])
+            col.column = ChainedVector([convert(Vector{Bool}, pertaskcolumns[i][j].column::vectype(T)) for i = 1:ntasks])
         elseif col.type !== Union{} && col.type <: SmallIntegers
-            col.column = ChainedVector([convert(Vector{col.type}, pertaskcolumns[i][j].column) for i = 1:ntasks])
+            col.column = ChainedVector([convert(Vector{col.type}, pertaskcolumns[i][j].column::vectype(T)) for i = 1:ntasks])
+        elseif pooled(col)
+            col.column = ChainedVector([pertaskcolumns[i][j].column::Vector{UInt32} for i = 1:ntasks])
         else
             col.column = ChainedVector([parent(pertaskcolumns[i][j].column) for i = 1:ntasks])
         end
@@ -481,6 +496,10 @@ function makepooled!(col)
     T = col.type
     r = isdefined(col, :refpool) ? col.refpool.refs : Refs{T === NeedsTypeDetection ? Missing : T}()
     column = isdefined(col, :column) ? col.column : UInt32[]
+    return makepooled2!(col, T, r, column)
+end
+
+function makepooled2!(col, ::Type{T}, r::Refs{T}, column) where {T}
     if col.anymissing
         r[missing] = UInt32(1)
     else
@@ -498,8 +517,13 @@ function makepooled!(col)
     return
 end
 
-function unpool!(col)
-    r = col.refpool.refs
+function unpool!(col, T, refpool)
+    r = refpool.refs
+    column = isdefined(col, :column) ? col.column : UInt32[]
+    return unpool2!(col, T, r, column)
+end
+
+function unpool2!(col, ::Type{T}, r::Refs{T}, column) where {T}
     if col.anymissing
         r[missing] = UInt32(1)
     end
@@ -509,20 +533,20 @@ function unpool!(col)
     end
     if col.type === PosLenString
         # unwrap the PosLenStrings, so they get handled by makeposlen!
-        col.column = [pool[ref].poslen for ref in col.column]
+        col.column = [pool[ref].poslen for ref in column]
     else
-        col.column = [pool[ref] for ref in col.column]
+        col.column = [pool[ref] for ref in column]
     end
     col.pool = 0.0
     return
 end
 
 function makeposlen!(col, T, ctx)
-    col.column = PosLenStringVector{T}(ctx.buf, col.column, ctx.options.e)
+    col.column = PosLenStringVector{T}(ctx.buf, col.column::Vector{PosLen}, ctx.options.e)
     return col.column
 end
 
-function parsefilechunk!(ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, opts, coloptions, ::Type{customtypes}) where {transpose, customtypes}
+function parsefilechunk!(ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, ::Type{customtypes}) where {transpose, customtypes}
     limit = ctx.limit
     row = 0
     startpos = pos
@@ -531,7 +555,7 @@ function parsefilechunk!(ctx::Context, buf, pos, len, rowsguess, rowoffset, colu
         while true
             row += 1
             # @show columns
-            @inbounds pos = parserow(startpos, row, numwarnings, ctx, buf, pos, len, rowsguess, rowoffset, columns, TR, opts, coloptions, customtypes)
+            @inbounds pos = parserow(startpos, row, numwarnings, ctx, buf, pos, len, rowsguess, rowoffset, columns, TR, customtypes)
             # @show columns
             row == limit && break
             (transpose ? all(c -> c.position >= c.endposition, columns) : pos > len) && break
@@ -565,7 +589,7 @@ end
 @noinline fatalerror(buf, pos, len, code, row, col) = throw(Error("thread = $(Threads.threadid()) fatal error, encountered an invalidly quoted field while parsing around row = $row, col = $col: \"$(String(buf[pos:pos+len-1]))\", error=$(Parsers.codes(code)), check your `quotechar` arguments or manually fix the field in the file itself"))
 @noinline toomanywwarnings() = @warn("thread = $(Threads.threadid()): too many warnings, silencing any further warnings")
 
-Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, options, coloptions, ::Type{customtypes}) where {transpose, customtypes}
+Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, ::Type{customtypes}) where {transpose, customtypes}
     # @show columns
     ncols = length(columns)
     for i = 1:ncols
@@ -574,70 +598,77 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
             pos = col.position
         end
         type = col.type
-        opts = coloptions === nothing ? options : coloptions[i]
+        cellstartpos = pos
         if type === HardMissing
-            pos, code = parsevalue!(Missing, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Missing, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === NeedsTypeDetection
-            pos, code = detect(buf, pos, len, opts, row, rowoffset, i, col, ctx, rowsguess)
+            pos, code = detectcell(buf, pos, len, row, rowoffset, i, col, ctx, rowsguess)
         elseif type === Int8
-            pos, code = parsevalue!(Int8, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Int8, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Int16
-            pos, code = parsevalue!(Int16, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Int16, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Int32
-            pos, code = parsevalue!(Int32, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Int32, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Int64
-            pos, code = parsevalue!(Int64, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Int64, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Int128
-            pos, code = parsevalue!(Int128, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Int128, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Float64
-            pos, code = parsevalue!(Float64, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Float64, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString1
-            pos, code = parsevalue!(InlineString1, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString1, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString3
-            pos, code = parsevalue!(InlineString3, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString3, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString7
-            pos, code = parsevalue!(InlineString7, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString7, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString15
-            pos, code = parsevalue!(InlineString15, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString15, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString31
-            pos, code = parsevalue!(InlineString31, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString31, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString63
-            pos, code = parsevalue!(InlineString63, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString63, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString127
-            pos, code = parsevalue!(InlineString127, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString127, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString255
-            pos, code = parsevalue!(InlineString255, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(InlineString255, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === String
-            pos, code = parsevalue!(String, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(String, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === PosLenString
-            pos, code = parsevalue!(PosLenString, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(PosLenString, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Date
-            pos, code = parsevalue!(Date, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Date, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === DateTime
-            pos, code = parsevalue!(DateTime, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(DateTime, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Time
-            pos, code = parsevalue!(Time, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Time, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Bool
-            pos, code = parsevalue!(Bool, buf, pos, len, opts, row, rowoffset, i, col)
+            pos, code = parsevalue!(Bool, buf, pos, len, row, rowoffset, i, col, ctx)
         else
             if customtypes !== Tuple{}
-                pos, code = parsecustom!(customtypes, buf, pos, len, opts, row, rowoffset, i, col)
+                pos, code = parsecustom!(customtypes, buf, pos, len, row, rowoffset, i, col, ctx)
             else
                 error("bad column type: $(type))")
             end
         end
         if promote_to_string(code)
             ctx.debug && println("promoting column i = $i to string from $(type) on chunk = $(Threads.threadid())")
-            newT = type <: InlineString ? String : ctx.stringtype === InlineString ? InlineString7 : ctx.stringtype
-            promotetostring!(ctx, buf, startpos, len, rowsguess, rowoffset, columns, TR, options, coloptions, customtypes, i, numwarnings, row, newT)
+            if type <: InlineString
+                newT = String
+            elseif ctx.stringtype === InlineString
+                str = Parsers.xparse(String, buf, cellstartpos, len, col.options)
+                newT = pickstringtype(InlineString, str.val.len)
+            else
+                newT = ctx.stringtype
+            end
+            promotetostring!(ctx, buf, startpos, len, rowsguess, rowoffset, columns, TR, customtypes, i, numwarnings, row, newT)
         end
         if transpose
             col.position = pos
         else
             if i < ncols
                 if Parsers.newline(code) || pos > len
-                    opts.silencewarnings || numwarnings[] > ctx.maxwarnings || notenoughcolumns(i, ncols, rowoffset + row)
-                    !opts.silencewarnings && numwarnings[] == ctx.maxwarnings && toomanywwarnings()
+                    ctx.silencewarnings || numwarnings[] > ctx.maxwarnings || notenoughcolumns(i, ncols, rowoffset + row)
+                    !ctx.silencewarnings && numwarnings[] == ctx.maxwarnings && toomanywwarnings()
                     numwarnings[] += 1
                     for j = (i + 1):ncols
                         columns[j].anymissing = true
@@ -646,25 +677,22 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
                 end
             elseif pos <= len && !Parsers.newline(code)
                 # extra columns on this row, let's widen
-                opts.silencewarnings || toomanycolumns(ncols, rowoffset + row)
+                ctx.silencewarnings || toomanycolumns(ncols, rowoffset + row)
                 j = i + 1
                 T = ctx.streaming ? Union{ctx.stringtype, Missing} : NeedsTypeDetection
                 while pos <= len && !Parsers.newline(code)
-                    col = Column(T)
+                    col = Column(T, ctx.options)
                     col.anymissing = ctx.streaming || rowoffset == 0 && row > 1 # assume all previous rows were missing
                     col.pool = ctx.pool
                     if T === NeedsTypeDetection
-                        pos, code = detect(buf, pos, len, opts, row, rowoffset, j, col, ctx, rowsguess)
+                        pos, code = detectcell(buf, pos, len, row, rowoffset, j, col, ctx, rowsguess)
                     else
                         # need to allocate
                         col.column = allocate(ctx.stringtype, ctx.rowsguess)
-                        pos, code = parsevalue!(ctx.stringtype, buf, pos, len, opts, row, rowoffset, j, col)
+                        pos, code = parsevalue!(ctx.stringtype, buf, pos, len, row, rowoffset, j, col, ctx)
                     end
                     j += 1
                     push!(columns, col)
-                    if coloptions !== nothing
-                        push!(coloptions, ctx.options)
-                    end
                 end
             end
         end
@@ -672,13 +700,12 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
     return pos
 end
 
-@noinline function _parseany(T, buf, pos, len, opts)::Tuple{Any, Int16, Int64, Int64, Int64}
-    return Parsers.xparse(T, buf, pos, len, opts)
-end
-
-function detect(buf, pos, len, opts, row, rowoffset, i, col, ctx, rowsguess)::Tuple{Int64, Int16}
+function detectcell(buf, pos, len, row, rowoffset, i, col, ctx, rowsguess)::Tuple{Int64, Int16}
     # debug && println("detecting on task $(Threads.threadid())")
-    x, code, tlen = detect(buf, pos, len, opts, false, ctx.downcast, rowoffset + row, i)
+    opts = col.options
+    # stats = Base.gc_num()
+    code, tlen, x, xT = detect(pass, buf, pos, len, opts, false, ctx.downcast, rowoffset + row, i)
+    # diff = GC_Diff(gc_num(), stats)
     if x === missing
         col.anymissing = true
         @goto finaldone
@@ -692,9 +719,10 @@ function detect(buf, pos, len, opts, row, rowoffset, i, col, ctx, rowsguess)::Tu
                 # type-mapping typeof(x) => newT
                 # this ultimate call to Parsers.xparse has no hope in inference (because of the typeof(x) => newT mapping)
                 # so we "outline" the call and assert the types of everything but `y` to make sure `code` and `tlen` stay type stable
-                y, code, vpos, vlen, tlen = _parseany(newT, buf, pos, len, opts)
+                res = _parseany(newT, buf, pos, len, opts)
+                code, tlen = res.code, res.tlen
                 if Parsers.ok(code)
-                    val = y
+                    val = res.val
                     @goto done
                 end
             else
@@ -703,17 +731,18 @@ function detect(buf, pos, len, opts, row, rowoffset, i, col, ctx, rowsguess)::Tu
             end
         end
     end
-@label stringdetect
-    _, code, vpos, vlen, tlen = Parsers.xparse(String, buf, pos, len, opts)
-    if newT === InlineString && vlen < DEFAULT_MAX_INLINE_STRING_LENGTH
-        newT = InlineStringType(vlen)
-        val, _, _, _, _ = _parseany(newT, buf, pos, len, opts)
+    # if we "fall through" to here, that means we either detected a string value
+    # or we're type-mapping from another detected type to string
+    str = Parsers.xparse(String, buf, pos, len, opts)
+    poslen = str.val
+    if newT === InlineString && poslen.len < DEFAULT_MAX_INLINE_STRING_LENGTH
+        newT = InlineStringType(poslen.len)
+        val = newT(PosLenString(buf, poslen, opts.e))
     elseif newT === PosLenString
         newT = PosLenString
-        val = PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code))
+        val = poslen
     else
         newT = String
-        poslen = PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code))
         val = String(buf, poslen, opts.e)
     end
 @label done
@@ -732,8 +761,10 @@ function detect(buf, pos, len, opts, row, rowoffset, i, col, ctx, rowsguess)::Tu
     return pos + tlen, code
 end
 
-function parsevalue!(::Type{type}, buf, pos, len, opts, row, rowoffset, i, col)::Tuple{Int64, Int16} where {type}
-    x, code, vpos, vlen, tlen = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
+function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::Tuple{Int64, Int16} where {type}
+    opts = col.options
+    res = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
+    code = res.code
     if !Parsers.invalid(code)
         if type !== Missing
             if Parsers.sentinel(code)
@@ -743,23 +774,21 @@ function parsevalue!(::Type{type}, buf, pos, len, opts, row, rowoffset, i, col):
                 if column isa Vector{UInt32}
                     if type === String || type === PosLenString
                         if Parsers.escapedstring(code)
-                            poslen = PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code))
-                            ref = getref!(col.refpool, type, String(buf, poslen, opts.e))
+                            ref = getref!(col.refpool, type, String(buf, res.val, opts.e))
                         else
-                            ref = getref!(col.refpool, type, PointerString(pointer(buf, vpos), vlen))
+                            poslen = res.val
+                            ref = getref!(col.refpool, type, PointerString(pointer(buf, poslen.pos), poslen.len), buf, poslen, opts.e)
                         end
                     else
-                        ref = getref!(col.refpool, type, x)
+                        ref = getref!(col.refpool, type, res.val)
                     end
                     @inbounds column[row] = ref
                 elseif type === String
-                    poslen = PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code))
-                    @inbounds (column::SVec2{String})[row] = String(buf, poslen, opts.e)
+                    @inbounds (column::SVec2{String})[row] = String(buf, res.val, opts.e)
                 elseif type === PosLenString
-                    poslen = PosLen(vpos, vlen, Parsers.sentinel(code), Parsers.escapedstring(code))
-                    @inbounds (column::Vector{PosLen})[row] = poslen
+                    @inbounds (column::Vector{PosLen})[row] = res.val
                 else
-                    @inbounds (column::vectype(type))[row] = x
+                    @inbounds (column::vectype(type))[row] = res.val
                 end
             end
         end
@@ -767,38 +796,39 @@ function parsevalue!(::Type{type}, buf, pos, len, opts, row, rowoffset, i, col):
         # something went wrong parsing
         if Parsers.invalidquotedfield(code)
             # this usually means parsing is borked because of an invalidly quoted field, hard error
-            fatalerror(buf, pos, tlen, code, rowoffset + row, i)
+            fatalerror(buf, pos, res.tlen, code, rowoffset + row, i)
         end
         if type !== Missing && type !== PosLenString && type !== String
             if col.userprovidedtype
-                if !opts.strict
-                    opts.silencewarnings || warning(type, buf, pos, tlen, code, rowoffset + row, i)
+                if !ctx.strict
+                    ctx.silencewarnings || warning(type, buf, pos, res.tlen, code, rowoffset + row, i)
                     col.anymissing = true
                 else
-                    stricterror(type, buf, pos, tlen, code, rowoffset + row, i)
+                    stricterror(type, buf, pos, res.tlen, code, rowoffset + row, i)
                 end
             else
                 if type === Int8 || type === Int16 || type === Int32 || type === Int64 || type === Int128
                     newT = _widen(type)
                     while newT !== nothing && !Parsers.ok(code)
-                        code = trytopromote!(type, newT, buf, pos, len, opts, col, row)
+                        code = trytopromote!(type, newT, buf, pos, len, col, row)
                         newT = _widen(newT)
                     end
                 elseif type === InlineString1 || type === InlineString3 || type === InlineString7 || type === InlineString15 || type === InlineString31 || type === InlineString63 || type === InlineString127
                     newT = widen(type)
                     while newT !== InlineString127
-                        newx, code, vpos, vlen, tlen = _parseany(newT, buf, pos, len, opts)
-                        if code > 0
+                        ret = _parseany(newT, buf, pos, len, opts)
+                        if !Parsers.invalid(ret.code)
                             col.type = newT
                             column = col.column
                             if column isa Vector{UInt32}
                                 col.refpool.refs = convert(Refs{newT}, col.refpool.refs)
-                                ref = getref!(col.refpool, newT, newx)
+                                ref = getref!(col.refpool, newT, ret.val)
                                 @inbounds column[row] = ref
                             else
                                 col.column = convert(SentinelVector{newT}, col.column::vectype(type))
+                                @inbounds col.column[row] = ret.val
                             end
-                            return pos + tlen, code
+                            return pos + ret.tlen, ret.code
                         end
                         newT = widen(newT)
                     end
@@ -809,21 +839,22 @@ function parsevalue!(::Type{type}, buf, pos, len, opts, row, rowoffset, i, col):
             end
         end
     end
-    return pos + tlen, code
+    return pos + res.tlen, code
 end
 
-@noinline function trytopromote!(::Type{from}, ::Type{to}, buf, pos, len, opts, col, row) where {from, to}
-    y, code, vpos, vlen, tlen = Parsers.xparse(to, buf, pos, len, opts)
+@noinline function trytopromote!(::Type{from}, ::Type{to}, buf, pos, len, col, row)::Int16 where {from, to}
+    res = Parsers.xparse(to, buf, pos, len, col.options)
+    code = res.code
     if !Parsers.invalid(code)
         col.type = to
         column = col.column
         if column isa Vector{UInt32}
             col.refpool.refs = convert(Refs{to}, col.refpool.refs)
-            ref = getref!(col.refpool, to, y)
+            ref = getref!(col.refpool, to, res.val)
             @inbounds column[row] = ref
         elseif column isa vectype(from)
             col.column = convert(promotevectype(to), column)
-            @inbounds col.column[row] = y
+            @inbounds col.column[row] = res.val
         end
     else
         code |= PROMOTE_TO_STRING
@@ -838,7 +869,7 @@ end
     end
 end
 
-@inline function getref!(refpool, ::Type{T}, key::PointerString)::UInt32 where {T}
+@inline function getref!(refpool, ::Type{T}, key::PointerString, buf, poslen, e)::UInt32 where {T}
     x = refpool.refs::Refs{T}
     index = Base.ht_keyindex2!(x, key)
     if index > 0
@@ -846,13 +877,17 @@ end
         ret = found_key::UInt32
     else
         @inbounds new = refpool.lastref += UInt32(1)
-        @inbounds Base._setindex!(x, new, T(key), -index)
+        if T === PosLenString
+            @inbounds Base._setindex!(x, new, T(buf, poslen, e), -index)
+        else
+            @inbounds Base._setindex!(x, new, T(key), -index)
+        end
         ret = new
     end
     return ret
 end
 
-@inline function parsecustom!(::Type{customtypes}, buf, pos, len, opts, row, rowoffset, i, col) where {customtypes}
+@inline function parsecustom!(::Type{customtypes}, buf, pos, len, row, rowoffset, i, col, ctx) where {customtypes}
     if @generated
         block = Expr(:block)
         push!(block.args, quote
@@ -862,7 +897,7 @@ end
             T = fieldtype(customtypes, i)
             pushfirst!(block.args, quote
                 if type === $T
-                    return parsevalue!($T, buf, pos, len, opts, row, rowoffset, i, col)
+                    return parsevalue!($T, buf, pos, len, row, rowoffset, i, col, ctx)
                 end
             end)
         end
@@ -872,12 +907,12 @@ end
         return block
     else
         # println("generated function failed")
-        return parsevalue!(col.type, buf, pos, len, opts, row, rowoffset, i, col)
+        return parsevalue!(col.type, buf, pos, len, row, rowoffset, i, col, ctx)
     end
 end
 
-@noinline function promotetostring!(ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, opts, coloptions, ::Type{customtypes}, column_to_promote, numwarnings, limit, stringtype) where {transpose, customtypes}
-    cols = [i == column_to_promote ? columns[i] : Column(Missing) for i = 1:length(columns)]
+@noinline function promotetostring!(ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, TR::Val{transpose}, ::Type{customtypes}, column_to_promote, numwarnings, limit, stringtype) where {transpose, customtypes}
+    cols = [i == column_to_promote ? columns[i] : Column(Missing, columns[i].options) for i = 1:length(columns)]
     col = cols[column_to_promote]
     if pooled(col) || maybepooled(col) || isnan(col.pool)
         col.refpool = RefPool(stringtype)
@@ -891,7 +926,7 @@ end
     if pos <= len && len > 0
         while row < limit
             row += 1
-            @inbounds pos = parserow(startpos, row, numwarnings, ctx, buf, pos, len, rowsguess, rowoffset, cols, TR, opts, coloptions, customtypes)
+            @inbounds pos = parserow(startpos, row, numwarnings, ctx, buf, pos, len, rowsguess, rowoffset, cols, TR, customtypes)
             pos > len && break
         end
     end

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -179,7 +179,7 @@ function checkwidencolumns!(r::Rows{t, ct, V}, cols) where {t, ct, V}
     if cols > length(r.names)
         # we widened while parsing this row, need to widen other supporting objects
         for i = (length(r.names) + 1):cols
-            push!(r.values, V === Any ? missing : Parsers.MISSING_BIT)
+            push!(r.values, V === Any ? missing : Base.bitcast(PosLen, Parsers.MISSING_BIT))
             nm = Symbol(:Column, i)
             push!(r.names, nm)
             r.lookup[nm] = length(r.names)
@@ -293,7 +293,7 @@ Base.@propagate_inbounds function Tables.getcolumn(r::Row2, ::Type{T}, i::Int, n
         elseif stringtype === PosLenString
             return PosLenString(getbuf(r), val, e)
         elseif stringtype === String
-            return String(getbuf(r), val, e)
+            return Parsers.getstring(getbuf(r), val, e)
         end
     else
         # at least some column types were manually provided


### PR DESCRIPTION
The motivation for the changes in Parsers.jl was to remove type parameters from `Parsers.Options`; this will enable CSV.jl to avoid needing to specialize on specific `Parsers.Options` when in hot parsing kernel loops. This should allow overall better initial latency when parsing, and certainly help avoid costly recompilation when different parsing options are passed.