### PR TITLE
Allow turning off missing value parsing

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -243,7 +243,7 @@ function Context(source,
     cq = something(closequotechar, quotechar) % UInt8
     trues = truestrings === nothing ? nothing : truestrings
     falses = falsestrings === nothing ? nothing : falsestrings
-    sentinel = (isempty(missingstring) || (missingstring isa Vector && length(missingstring) == 1 && missingstring[1] == "")) ? missing : missingstring isa String ? [missingstring] : missingstring
+    sentinel = missingstring === nothing ? missingstring : (isempty(missingstring) || (missingstring isa Vector && length(missingstring) == 1 && missingstring[1] == "")) ? missing : missingstring isa String ? [missingstring] : missingstring
 
     if delim === nothing
         del = isa(source, AbstractString) && endswith(source, ".tsv") ? UInt8('\t') :

--- a/src/keyworddocs.jl
+++ b/src/keyworddocs.jl
@@ -18,7 +18,7 @@ const KEYWORD_DOCS = """
 
 ## Parsing options:
 
-  * `missingstring`: either a `String`, or `Vector{String}` to use as sentinel values that will be parsed as `missing`; by default, only an empty field (two consecutive delimiters) is considered `missing`
+  * `missingstring`: either a `nothing`, `String`, or `Vector{String}` to use as sentinel values that will be parsed as `missing`; if `nothing` is passed, no sentinel/missing values will be parsed; by default, `missingstring=""`, which means only an empty field (two consecutive delimiters) is considered `missing`
   * `delim=','`: a `Char` or `String` that indicates how columns are delimited in a file; if no argument is provided, parsing will try to detect the most consistent delimiter on the first 10 rows of the file
   * `ignorerepeated::Bool=false`: whether repeated (consecutive/sequential) delimiters should be ignored while parsing; useful for fixed-width files with delimiter padding between cells
   * `quoted::Bool=true`: whether parsing should check for `quotechar` at the start/end of cells

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -638,4 +638,9 @@ f = CSV.File(IOBuffer("x\n\0\n"))
 f = CSV.File(IOBuffer("x\n\"abc\"\n"); quoted=false)
 @test f.x[1] == "\"abc\""
 
+# 768
+f = CSV.File(IOBuffer("a,b,c\n1,2,3\n,null,4\n"), missingstring=nothing)
+@test eltype(f.a) <: AbstractString
+@test f.a[2] == ""
+
 end


### PR DESCRIPTION
Fixes #768. We can potentially allow passing `missingstring` per column,
but that seems like a more rare need than turning off missing value
parsing all together, which allows string columns to parse empty strings
correctly by default. The reason per column isn't quite as compelling is
that you can already pass a vector of missing string values to
`missingstring` to check any of the values for `missing`. So it would
only be the use-case of wanting to parse a missing string in one column
_but not_ another where per-column missing strings would be useful.