### PR TITLE
Fix select/drop on CSV.Rows

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -176,13 +176,13 @@ Base.IteratorSize(::Type{<:Rows}) = Base.SizeUnknown()
 end
 
 function checkwidencolumns!(r::Rows{t, ct, V}, cols) where {t, ct, V}
-    if cols > length(r.columns)
+    if cols > length(r.values)
         # we widened while parsing this row, need to widen other supporting objects
-        for i = (length(r.columns) + 1):cols
+        for i = (length(r.values) + 1):cols
             push!(r.values, V === Any ? missing : Base.bitcast(PosLen, Parsers.MISSING_BIT))
             nm = Symbol(:Column, i)
             push!(r.names, nm)
-            r.lookup[nm] = length(r.columns)
+            r.lookup[nm] = length(r.values)
             push!(r.columnmap, i)
         end
     end

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -176,13 +176,13 @@ Base.IteratorSize(::Type{<:Rows}) = Base.SizeUnknown()
 end
 
 function checkwidencolumns!(r::Rows{t, ct, V}, cols) where {t, ct, V}
-    if cols > length(r.names)
+    if cols > length(r.columns)
         # we widened while parsing this row, need to widen other supporting objects
-        for i = (length(r.names) + 1):cols
+        for i = (length(r.columns) + 1):cols
             push!(r.values, V === Any ? missing : Base.bitcast(PosLen, Parsers.MISSING_BIT))
             nm = Symbol(:Column, i)
             push!(r.names, nm)
-            r.lookup[nm] = length(r.names)
+            r.lookup[nm] = length(r.columns)
             push!(r.columnmap, i)
         end
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -643,4 +643,9 @@ f = CSV.File(IOBuffer("a,b,c\n1,2,3\n,null,4\n"), missingstring=nothing)
 @test eltype(f.a) <: AbstractString
 @test f.a[2] == ""
 
+# 858
+row = first(CSV.Rows(IOBuffer("a,b,c\n1,2,3\n\n"); select=[:a, :c]))
+@test length(row) == 2
+@test row.a == "1" && row.c == "3"
+
 end


### PR DESCRIPTION
The new column-widening functionality regressed using select/drop
keyword args for `CSV.Rows`. May fix #858.