### PR TITLE
Add extra validation on types/dateformat/pool keyword args

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -128,6 +128,17 @@ function checkvaliddelim(delim)
                             "the following delimiters are invalid: '\\r', '\\n', '\\0'"))
 end
 
+function checkinvalidcolumns(dict, argname, ncols, names)
+    for (k, _) in dict
+        if k isa Integer
+            (0 < k <= ncols) || throw(ArgumentError("invalid column number provided in `$argname` keyword argument: $k. Column number must be 0 < i <= $ncols as detected in the data"))
+        else
+            Symbol(k) in names || throw(ArgumentError("invalid column name provided in `$argname` keyword argument: $k. Valid column names detected in the data are: $names"))
+        end
+    end
+    return
+end
+
 function Context(source,
     # file options
     # header can be a row number, range of rows, or actual string vector
@@ -342,6 +353,7 @@ function Context(source,
                 customtypes = tupcat(customtypes, nonstandardtype(col.type))
             end
         end
+        checkinvalidcolumns(types, "types", ncols, names)
     else
         T = types === nothing ? (streaming ? Union{stringtype, Missing} : NeedsTypeDetection) : types
         columns = Vector{Column}(undef, ncols)
@@ -375,6 +387,7 @@ function Context(source,
                 columns[i].options = Parsers.Options(sentinel, wh1, wh2, oq, cq, eq, d, decimal, trues, falses, df, ignorerepeated, ignoreemptyrows, comment, true, parsingdebug)
             end
         end
+        checkinvalidcolumns(dateformat, "dateformat", ncols, names)
     end
 
     # pool keyword
@@ -389,6 +402,7 @@ function Context(source,
             for i = 1:ncols
                 columns[i].pool = getpool(getordefault(pool, names[i], i, 0.0))
             end
+            checkinvalidcolumns(pool, "pool", ncols, names)
         else
             finalpool = getpool(pool)
         end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -648,4 +648,17 @@ row = first(CSV.Rows(IOBuffer("a,b,c\n1,2,3\n\n"); select=[:a, :c]))
 @test length(row) == 2
 @test row.a == "1" && row.c == "3"
 
+# 802; throw error when invalid columns passed in types/dateformat/pool keyword arguments
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); types=Dict(4 => Float64))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); types=Dict(:d => Float64))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); types=Dict("d" => Float64))
+
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); dateformat=Dict(4 => "dd/mm/yyyy"))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); dateformat=Dict(:d => "dd/mm/yyyy"))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); dateformat=Dict("d" => "dd/mm/yyyy"))
+
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict(4 => true))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict(:d => true))
+@test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict("d" => true))
+
 end


### PR DESCRIPTION
Fixes #802. The original issue was the user didn't realize the column
name passed in the `types` `Dict` argument didn't quite match the column
name parsed in the file, and `CSV.File` just silently ignored the
"unused" value in the dict and auto-type-detected the column type. This
PR adds an extra validation step once we've parsed the column names to
check that there aren't column names in the `types`/`dateformat`/`pool`
keyword arguments that don't exist in the data itself. If so, an
`ArgumentError` will be thrown, which should help users in this scenario
in the future to realize something is amiss.