### PR TITLE
Respect typemap in type promotion cases while parsing

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -833,6 +833,11 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
                 if type === Int8 || type === Int16 || type === Int32 || type === Int64 || type === Int128
                     newT = _widen(type)
                     while newT !== nothing && !Parsers.ok(code)
+                        newT = get(ctx.typemap, newT, newT)
+                        if newT isa StringTypes
+                            code |= PROMOTE_TO_STRING
+                            break
+                        end
                         code = trytopromote!(type, newT, buf, pos, len, col, row)
                         newT = _widen(newT)
                     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -661,4 +661,9 @@ row = first(CSV.Rows(IOBuffer("a,b,c\n1,2,3\n\n"); select=[:a, :c]))
 @test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict(:d => true))
 @test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict("d" => true))
 
+# 871
+
+f = CSV.File(IOBuffer("a,b,c\n1,2,3\n3.14,5,6\n"); typemap=Dict(Float64 => String))
+@test f.a isa Vector{<:AbstractString}
+
 end


### PR DESCRIPTION
Fixes #871. The issue here is that in our parsevalue! promotion logic,
we weren't considering whether the use may want to typemap a _promoted_
type to another type; in the original issue, a column started out as
detected as integer, then promoted to float, but the user wanted to
typemap any floats to strings. This fix just accounts for any
typemapping that may occur during promotion.