### PR TITLE
Improve time-to-first-read via precompile + despecialization

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -74,7 +74,7 @@ function Chunks(source;
     debug::Bool=false,
     parsingdebug::Bool=false)
 
-    ctx = Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
     !ctx.threaded && throw(ArgumentError("unable to iterate chunks from input file source"))
     foreach(col -> col.lock = ReentrantLock(), ctx.columns)
     return Chunks(ctx)

--- a/src/context.jl
+++ b/src/context.jl
@@ -77,35 +77,6 @@ function Column(x::Column)
     return y
 end
 
-struct Context
-    transpose::Val
-    name::String
-    names::Vector{Symbol}
-    rowsguess::Int64
-    cols::Int
-    buf::AbstractVector{UInt8}
-    datapos::Int64
-    len::Int
-    datarow::Int
-    options::Parsers.Options
-    columns::Vector{Column}
-    pool::Float64
-    downcast::Bool
-    customtypes::Type
-    typemap::Dict{Type, Type}
-    stringtype::StringTypes
-    limit::Int
-    threaded::Bool
-    ntasks::Int
-    chunkpositions::Vector{Int}
-    strict::Bool
-    silencewarnings::Bool
-    maxwarnings::Int
-    debug::Bool
-    tempfile::Union{String, Nothing}
-    streaming::Bool
-end
-
 """
     isvaliddelim(delim)
 
@@ -139,33 +110,62 @@ function checkinvalidcolumns(dict, argname, ncols, names)
     return
 end
 
-function Context(source,
+struct Context
+    transpose::Val
+    name::String
+    names::Vector{Symbol}
+    rowsguess::Int64
+    cols::Int
+    buf::AbstractVector{UInt8}
+    datapos::Int64
+    len::Int
+    datarow::Int
+    options::Parsers.Options
+    columns::Vector{Column}
+    pool::Float64
+    downcast::Bool
+    customtypes::Type
+    typemap::Dict{Type, Type}
+    stringtype::StringTypes
+    limit::Int
+    threaded::Bool
+    ntasks::Int
+    chunkpositions::Vector{Int}
+    strict::Bool
+    silencewarnings::Bool
+    maxwarnings::Int
+    debug::Bool
+    tempfile::Union{String, Nothing}
+    streaming::Bool
+end
+
+@refargs function Context(source,
     # file options
     # header can be a row number, range of rows, or actual string vector
-    header,
-    normalizenames,
-    datarow,
-    skipto,
-    footerskip,
-    transpose,
-    comment,
-    ignoreemptyrows,
+    header::Union{Integer, Vector{Symbol}, Vector{String}, AbstractVector{<:Integer}},
+    normalizenames::Bool,
+    datarow::Integer,
+    skipto::Integer,
+    footerskip::Integer,
+    transpose::Bool,
+    comment::Union{String, Nothing},
+    ignoreemptyrows::Bool,
     ignoreemptylines,
     select,
     drop,
-    limit,
-    buffer_in_memory,
+    limit::Union{Integer, Nothing},
+    buffer_in_memory::Bool,
     threaded,
-    ntasks,
+    ntasks::Union{Nothing, Integer},
     tasks,
-    rows_to_check,
+    rows_to_check::Integer,
     lines_to_check,
     # parsing options
     missingstrings,
     missingstring,
     delim,
-    ignorerepeated,
-    quoted,
+    ignorerepeated::Bool,
+    quoted::Bool,
     quotechar,
     openquotechar,
     closequotechar,
@@ -180,15 +180,15 @@ function Context(source,
     types,
     typemap,
     pool,
-    downcast,
+    downcast::Bool,
     lazystrings,
     stringtype,
-    strict,
-    silencewarnings,
-    maxwarnings,
-    debug,
-    parsingdebug,
-    streaming)
+    strict::Bool,
+    silencewarnings::Bool,
+    maxwarnings::Integer,
+    debug::Bool,
+    parsingdebug::Bool,
+    streaming::Bool)
 
     # initial argument validation and adjustment
     @inbounds begin

--- a/src/detection.jl
+++ b/src/detection.jl
@@ -1,5 +1,5 @@
 # figure out at what byte position the header row(s) start and at what byte position the data starts
-function detectheaderdatapos(buf, pos, len, oq, eq, cq, cmt, ignoreemptyrows, header, skipto)
+function detectheaderdatapos(buf, pos, len, oq, eq, cq, cmt, ignoreemptyrows, @nospecialize(header), skipto)
     headerpos = 0
     datapos = 1
     if header isa Integer
@@ -162,7 +162,7 @@ function incr!(c::ByteValueCounter, b::UInt8)
 end
 
 # given the various header and normalization options, figure out column names for a file
-function detectcolumnnames(buf, headerpos, datapos, len, options, header, normalizenames)
+function detectcolumnnames(buf, headerpos, datapos, len, options, @nospecialize(header), normalizenames)
     if header isa Union{AbstractVector{Symbol}, AbstractVector{String}}
         fields, pos = readsplitline(buf, datapos, len, options)
         isempty(header) && return [Symbol(:Column, i) for i = 1:length(fields)]
@@ -230,7 +230,7 @@ function skiptorow(buf, pos, len, oq, eq, cq, cmt, ignoreemptyrows, cur, dest)
 end
 
 # read a single row, splitting cells on delimiters; used for parsing column names from header row(s)
-function readsplitline(buf, pos, len, options::Parsers.Options)
+function readsplitline(buf, pos, len, options)
     vals = String[]
     (pos > len || pos == 0) && return vals, pos
     col = 1
@@ -337,7 +337,7 @@ ColumnProperties(T) = ColumnProperties(T, 0x00)
     end
 end
 
-function findchunkrowstart(ranges, i, buf, opts, downcast, ncols, rows_to_check, columns, columnlock, stringtype, totalbytes, totalrows, succeeded)
+function findchunkrowstart(ranges, i, buf, opts, downcast, ncols, rows_to_check, columns, columnlock, @nospecialize(stringtype), totalbytes, totalrows, succeeded)
     pos = ranges[i]
     len = ranges[i + 1]
     while pos <= len
@@ -456,7 +456,7 @@ end
 # right # of expected columns then we move on to the next file chunk byte position. If we fail, we start over
 # at the byte position, assuming we were in a quoted field (and encountered a newline inside the quoted
 # field the first time through)
-function findrowstarts!(buf, opts, ranges, ncols, columns, stringtype, downcast, rows_to_check=5)
+function findrowstarts!(buf, opts, ranges, ncols, columns, @nospecialize(stringtype), downcast, rows_to_check=5)
     totalbytes = Threads.Atomic{Int}(0)
     totalrows = Threads.Atomic{Int}(0)
     succeeded = Threads.Atomic{Bool}(true)
@@ -513,7 +513,7 @@ function findrowstarts!(buf, opts, ranges, ncols, columns, stringtype, downcast,
     return totalbytes[] / finalrows, true
 end
 
-function detecttranspose(buf, pos, len, options, header, skipto, normalizenames)
+function detecttranspose(buf, pos, len, options, @nospecialize(header), skipto, normalizenames)
     if isa(header, Integer) && header > 0
         # skip to header column to read column names
         row, pos = skiptofield!(buf, pos, len, options, 1, header)

--- a/src/file.jl
+++ b/src/file.jl
@@ -214,7 +214,7 @@ function File(source::Union{Vector{UInt8}, IO, Cmd, AbstractString, AbstractPath
     # delim=nothing;ignorerepeated=false;quoted=true;quotechar='"';openquotechar=nothing;closequotechar=nothing;escapechar='"';dateformat=nothing;
     # dateformats=nothing;decimal=UInt8('.');truestrings=nothing;falsestrings=nothing;type=nothing;types=nothing;typemap=Dict{Type,Type}();
     # pool=CSV.DEFAULT_POOL;downcast=false;lazystrings=false;stringtype=String;strict=false;silencewarnings=false;maxwarnings=100;debug=true;parsingdebug=false;
-    ctx = Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
     return File(ctx)
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,29 +1,31 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    # Base.precompile(Tuple{Core.kwftype(typeof(CSV.Type)),NamedTuple{(:debug,),Tuple{Bool}},Type{CSV.File},CSV.Header{false,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Array{UInt8,1}}})
-    # Base.precompile(Tuple{Type{CSV.File},String})
-    # Base.precompile(Tuple{Type{CSV.Header{false,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Array{UInt8,1}}},String,Array{Symbol,1},Int64,Int64,UInt8,Array{UInt8,1},Int64,Int64,Int64,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Nothing,Array{Int64,1},Array{Type,1},Array{UInt8,1},Array{Int64,1},Float64,Bool,Type{T} where T})
-    # Base.precompile(Tuple{typeof(CSV.detectcolumnnames),Array{UInt8,1},Int64,Int64,Int64,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Int64,Bool})
-    # Base.precompile(Tuple{typeof(CSV.makechain),Type{Array{Union{Missing, Bool},1}},Array{Union{Missing, Bool},1},Int64,Int64,Array{Array{AbstractArray{T,1} where T,1},1},Int64})
-    # Base.precompile(Tuple{typeof(CSV.multithreadparse),Array{Type,1},Array{UInt8,1},Array{UInt8,1},Int64,Int64,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Nothing,Int64,Int64,Float64,Array{CSV.RefPool,1},Int64,Dict{Type,Type},Bool,Type{T} where T,Int64,Int64,Bool})
-    # Base.precompile(Tuple{typeof(CSV.parsefilechunk!),Val{false},Int64,Dict{Type,Type},Array{AbstractArray{T,1} where T,1},Array{UInt8,1},Int64,Int64,Int64,Array{Int64,1},Float64,Array{CSV.RefPool,1},Int64,Int64,Array{Type,1},Array{UInt8,1},Bool,Parsers.Options{false,false,true,false,Missing,UInt8,Nothing},Nothing,Type{Tuple{}},Int})
-    # Base.precompile(Tuple{typeof(CSV.promote_types),Any,Any})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,Array{Union{Missing, Bool},1}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,ChainedVector{Union{Missing, Bool},Array{Union{Missing, Bool},1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,PooledArrays.PooledArray{Union{Missing, String},UInt32,1,Array{UInt32,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,PooledArrays.PooledArray{Union{Missing, String},UInt32,1,ChainedVector{UInt32,Array{UInt32,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.Date,1,Dates.Date,Missing,Array{Dates.Date,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.Date,1,Dates.Date,Missing,ChainedVector{Dates.Date,Array{Dates.Date,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.DateTime,1,Dates.DateTime,Missing,Array{Dates.DateTime,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.DateTime,1,Dates.DateTime,Missing,ChainedVector{Dates.DateTime,Array{Dates.DateTime,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.Time,1,Dates.Time,Missing,Array{Dates.Time,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Dates.Time,1,Dates.Time,Missing,ChainedVector{Dates.Time,Array{Dates.Time,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Float64,1,Float64,Missing,Array{Float64,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Float64,1,Float64,Missing,ChainedVector{Float64,Array{Float64,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Int64,1,Int64,Missing,Array{Int64,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{Int64,1,Int64,Missing,ChainedVector{Int64,Array{Int64,1}}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{String,1,UndefInitializer,Missing,Array{String,1}}}})
-    # isdefined(CSV, Symbol("#28#29")) && Base.precompile(Tuple{getfield(CSV, Symbol("#28#29")),Tuple{Symbol,SentinelArray{String,1,UndefInitializer,Missing,ChainedVector{String,Array{String,1}}}}})
-    # isdefined(CSV, Symbol("#34#39")) && Base.precompile(Tuple{getfield(CSV, Symbol("#34#39"))})
-    # isdefined(CSV, Symbol("#36#41")) && Base.precompile(Tuple{getfield(CSV, Symbol("#36#41"))})
+    @assert Base.precompile(Tuple{typeof(parsefilechunk!),Context,Vector{UInt8},Int64,Int64,Int64,Int64,Vector{Column},Val{false},Type{Tuple{}}})   # time: 1.0312017
+    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{BigFloat},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.5886147
+    @assert Base.precompile(Tuple{typeof(detect),String})   # time: 0.14655608
+    @assert Base.precompile(Tuple{typeof(write),Base.BufferStream,NamedTuple{(:a, :b), Tuple{Vector{Int64}, Vector{Float64}}}})   # time: 0.06289695
+    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{BigInt},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.0527356
+    @assert Base.precompile(Tuple{typeof(getname),Cmd})   # time: 0.050515886
+    @assert Base.precompile(Tuple{typeof(write),IOBuffer,NamedTuple{(:x,), Tuple{Vector{Char}}}})   # time: 0.035573076
+    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{UInt32},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.035170615
+    @assert Base.precompile(Tuple{Type{File},Vector{IOBuffer}})   # time: 0.033758428
+    @assert Base.precompile(Tuple{Type{File},Context,Bool})   # time: 0.033758428
+    @assert Base.precompile(Tuple{Type{Context},Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg})
+    @assert Base.precompile(Tuple{typeof(write),Base.Process,NamedTuple{(:col1, :col2, :col3), Tuple{Vector{Int64}, Vector{Int64}, Vector{Int64}}}})   # time: 0.03311246
+    @assert Base.precompile(Tuple{typeof(detectcolumnnames),Vector{UInt8},Int64,Int64,Int64,Parsers.Options,Any,Bool})   # time: 0.027399136
+    @assert Base.precompile(Tuple{typeof(findchunkrowstart),Vector{Int64},Int64,Vector{UInt8},Parsers.Options,Bool,Int64,Int64,Vector{Column},ReentrantLock,Any,Base.Threads.Atomic{Int64},Base.Threads.Atomic{Int64},Base.Threads.Atomic{Bool}})   # time: 0.026987862
+    @assert Base.precompile(Tuple{typeof(write),String,Vector{NamedTuple{(:a,), Tuple{String}}}})   # time: 0.022341058
+    @assert Base.precompile(Tuple{typeof(makepooled!),Column})   # time: 0.020273618
+    @assert Base.precompile(Tuple{typeof(unpool!),Column,Type,RefPool})   # time: 0.019640453
+    @assert Base.precompile(Tuple{typeof(Tables.getcolumn),File,Symbol})   # time: 0.018873245
+    @assert Base.precompile(Tuple{typeof(getsource),Vector{UInt8},Bool})   # time: 0.013699824
+    @assert Base.precompile(Tuple{typeof(detectheaderdatapos),Vector{UInt8},Int64,Int64,UInt8,UInt8,UInt8,Tuple{Ptr{UInt8}, Int64},Bool,Any,Int64})   # time: 0.012563237
+    @assert Base.precompile(Tuple{typeof(detectheaderdatapos),Vector{UInt8},Int64,Int64,UInt8,UInt8,UInt8,Nothing,Bool,Any,Int64})   # time: 0.011714202
+    @assert Base.precompile(Tuple{typeof(Tables.schema),File})   # time: 0.011355454
+    @assert Base.precompile(Tuple{typeof(detectdelimandguessrows),Vector{UInt8},Int64,Int64,Int64,UInt8,UInt8,UInt8,UInt8,Tuple{Ptr{UInt8}, Int64},Bool})   # time: 0.010538074
+    @assert Base.precompile(Tuple{Type{Context},Val{false},String,Vector{Symbol},Int64,Int64,Vector{UInt8},Int64,Int64,Int64,Parsers.Options,Vector{Column},Float64,Bool,Type,Dict{DataType, DataType},Type,Int64,Bool,Int64,Vector{Int64},Bool,Bool,Int64,Bool,Nothing,Bool})   # time: 0.010367362
+    @assert Base.precompile(Tuple{typeof(detectdelimandguessrows),Vector{UInt8},Int64,Int64,Int64,UInt8,UInt8,UInt8,UInt8,Nothing,Bool})   # time: 0.010337504
+    @assert Base.precompile(Tuple{typeof(warning),Type,Vector{UInt8},Int64,Int64,Int16,Int64,Int64})   # time: 0.008919449
+    @assert Base.precompile(Tuple{Type{Rows},String})   # time: 0.008758181
+    @assert Base.precompile(Tuple{Type{Rows},IOBuffer})   # time: 0.008604496
 end

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -115,8 +115,7 @@ function Rows(source;
     parsingdebug::Bool=false,
     reusebuffer::Bool=false,
     )
-    @nospecialize
-    ctx = Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, nothing, nothing, 0, nothing, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, true)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, nothing, nothing, 0, nothing, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, true)
     foreach(col -> col.pool = 0.0, ctx.columns)
     allocate!(ctx.columns, 1)
     values = all(x->x.type === ctx.stringtype && x.anymissing, ctx.columns) && ctx.stringtype === PosLenString ? Vector{PosLen}(undef, ctx.cols) : Vector{Any}(undef, ctx.cols)


### PR DESCRIPTION
Been wanting/needing to do this for a while. Worked through the
excellent tutorials in
https://timholy.github.io/SnoopCompile.jl/stable/snoopi_deep_parcel/ to
help figure out cases where we were overspecializing certain methods
(`CSV.Context`) and generating useful precompile statements. On my
machine, this reduces the time-to-first-read (TTFR) from ~8s to ~1.5,
while package loading time goes from 3s to 10s, which both seem like
good tradeoffs. To avoid overspecialization of `CSV.Context` method,
which has a huge method body, we introduce a simple `Arg` wrapper struct
to kill inference and make the method signature concrete. The `@refargs`
macro conveniently wraps each arg in a _call_ with `Arg(x)`, and for a
_definition_, it annotates each arg as `x::Arg` and inserts an unwrap as
the first thing in the method body like `x = x[]::Int` where `x` was
declared as `x::Int` in the argument list.

One thing I noticed that I would still like to look into if time is that if we do `f = CSV.File(IOBuffer("a,b,c\n1,2,3\n\n"))` in a fresh session, it takes ~1.5s, but then if we call like `f = CSV.File(IOBuffer("a,b,c\n1,2,3\n\n"); header=false)`, it takes 3s to......recompile a bunch of stuff I guess? I'd love to figure out why that's causing so much recompiling.