### PR TITLE
A little refactoring to improve inference and precompilation

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -39,6 +39,8 @@ const DEFAULT_MAX_INLINE_STRING_LENGTH = 32
 const TRUE_STRINGS = ["true", "True", "TRUE", "T", "1"]
 const FALSE_STRINGS = ["false", "False", "FALSE", "F", "0"]
 const ValidSources = Union{Vector{UInt8}, SubArray{UInt8, 1, Vector{UInt8}}, IO, Cmd, AbstractString, AbstractPath}
+const MAX_INPUT_SIZE = Int64(2)^42
+const EMPTY_INT_ARRAY = Int64[]
 
 include("keyworddocs.jl")
 include("utils.jl")
@@ -66,5 +68,11 @@ end
 
 include("precompile.jl")
 _precompile_()
+
+function __init__()
+    CSV.File(IOBuffer(PRECOMPILE_DATA))
+    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
+end
 
 end # module

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -71,8 +71,8 @@ _precompile_()
 
 function __init__()
     CSV.File(IOBuffer(PRECOMPILE_DATA))
-    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
+    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end
 
 end # module

--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -70,7 +70,7 @@ include("precompile.jl")
 _precompile_()
 
 function __init__()
-    CSV.File(IOBuffer(PRECOMPILE_DATA))
+    # CSV.File(IOBuffer(PRECOMPILE_DATA))
     # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
     # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1,3.14,2019-01-01,2019-01-01T01:02:03,true,,hey,abc,2\n2,NaN,2019-01-02,2019-01-03T01:02:03,false,,there,abc,3.14\n"
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    CSV.File(IOBuffer(PRECOMPILE_DATA))
-    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
+    # CSV.File(IOBuffer(PRECOMPILE_DATA))
+    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,31 +1,7 @@
+const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1,3.14,2019-01-01,2019-01-01T01:02:03,true,,hey,abc,2\n2,NaN,2019-01-02,2019-01-03T01:02:03,false,,there,abc,3.14\n"
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert Base.precompile(Tuple{typeof(parsefilechunk!),Context,Vector{UInt8},Int64,Int64,Int64,Int64,Vector{Column},Val{false},Type{Tuple{}}})   # time: 1.0312017
-    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{BigFloat},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.5886147
-    @assert Base.precompile(Tuple{typeof(detect),String})   # time: 0.14655608
-    @assert Base.precompile(Tuple{typeof(write),Base.BufferStream,NamedTuple{(:a, :b), Tuple{Vector{Int64}, Vector{Float64}}}})   # time: 0.06289695
-    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{BigInt},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.0527356
-    @assert Base.precompile(Tuple{typeof(getname),Cmd})   # time: 0.050515886
-    @assert Base.precompile(Tuple{typeof(write),IOBuffer,NamedTuple{(:x,), Tuple{Vector{Char}}}})   # time: 0.035573076
-    @assert Base.precompile(Tuple{typeof(parsevalue!),Type{UInt32},Vector{UInt8},Int64,Int64,Int64,Int64,Int64,Column,Context})   # time: 0.035170615
-    @assert Base.precompile(Tuple{Type{File},Vector{IOBuffer}})   # time: 0.033758428
-    @assert Base.precompile(Tuple{Type{File},Context,Bool})   # time: 0.033758428
-    @assert Base.precompile(Tuple{Type{Context},Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg,Arg})
-    @assert Base.precompile(Tuple{typeof(write),Base.Process,NamedTuple{(:col1, :col2, :col3), Tuple{Vector{Int64}, Vector{Int64}, Vector{Int64}}}})   # time: 0.03311246
-    @assert Base.precompile(Tuple{typeof(detectcolumnnames),Vector{UInt8},Int64,Int64,Int64,Parsers.Options,Any,Bool})   # time: 0.027399136
-    @assert Base.precompile(Tuple{typeof(findchunkrowstart),Vector{Int64},Int64,Vector{UInt8},Parsers.Options,Bool,Int64,Int64,Vector{Column},ReentrantLock,Any,Base.Threads.Atomic{Int64},Base.Threads.Atomic{Int64},Base.Threads.Atomic{Bool}})   # time: 0.026987862
-    @assert Base.precompile(Tuple{typeof(write),String,Vector{NamedTuple{(:a,), Tuple{String}}}})   # time: 0.022341058
-    @assert Base.precompile(Tuple{typeof(makepooled!),Column})   # time: 0.020273618
-    @assert Base.precompile(Tuple{typeof(unpool!),Column,Type,RefPool})   # time: 0.019640453
-    @assert Base.precompile(Tuple{typeof(Tables.getcolumn),File,Symbol})   # time: 0.018873245
-    @assert Base.precompile(Tuple{typeof(getsource),Vector{UInt8},Bool})   # time: 0.013699824
-    @assert Base.precompile(Tuple{typeof(detectheaderdatapos),Vector{UInt8},Int64,Int64,UInt8,UInt8,UInt8,Tuple{Ptr{UInt8}, Int64},Bool,Any,Int64})   # time: 0.012563237
-    @assert Base.precompile(Tuple{typeof(detectheaderdatapos),Vector{UInt8},Int64,Int64,UInt8,UInt8,UInt8,Nothing,Bool,Any,Int64})   # time: 0.011714202
-    @assert Base.precompile(Tuple{typeof(Tables.schema),File})   # time: 0.011355454
-    @assert Base.precompile(Tuple{typeof(detectdelimandguessrows),Vector{UInt8},Int64,Int64,Int64,UInt8,UInt8,UInt8,UInt8,Tuple{Ptr{UInt8}, Int64},Bool})   # time: 0.010538074
-    @assert Base.precompile(Tuple{Type{Context},Val{false},String,Vector{Symbol},Int64,Int64,Vector{UInt8},Int64,Int64,Int64,Parsers.Options,Vector{Column},Float64,Bool,Type,Dict{DataType, DataType},Type,Int64,Bool,Int64,Vector{Int64},Bool,Bool,Int64,Bool,Nothing,Bool})   # time: 0.010367362
-    @assert Base.precompile(Tuple{typeof(detectdelimandguessrows),Vector{UInt8},Int64,Int64,Int64,UInt8,UInt8,UInt8,UInt8,Nothing,Bool})   # time: 0.010337504
-    @assert Base.precompile(Tuple{typeof(warning),Type,Vector{UInt8},Int64,Int64,Int16,Int64,Int64})   # time: 0.008919449
-    @assert Base.precompile(Tuple{Type{Rows},String})   # time: 0.008758181
-    @assert Base.precompile(Tuple{Type{Rows},IOBuffer})   # time: 0.008604496
+    CSV.File(IOBuffer(PRECOMPILE_DATA))
+    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,6 +2,6 @@ const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     CSV.File(IOBuffer(PRECOMPILE_DATA))
-    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
+    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1,3.14,2019-01-01,2019-01-01T01:02:03,true,,hey,abc,2\n2,NaN,2019-01-02,2019-01-03T01:02:03,false,,there,abc,3.14\n"
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    # CSV.File(IOBuffer(PRECOMPILE_DATA))
-    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
+    CSV.File(IOBuffer(PRECOMPILE_DATA))
+    foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
+    CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1,3.14,2019-01-01,2019-01-01T01:02:03,true,,hey,abc,2\n2,NaN,2019-01-02,2019-01-03T01:02:03,false,,there,abc,3.14\n"
 function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    CSV.File(IOBuffer(PRECOMPILE_DATA))
+    # ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    # CSV.File(IOBuffer(PRECOMPILE_DATA))
     # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
     # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
 end

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -6,7 +6,7 @@ end
 # no automatic type inference is done, but types are allowed to be passed
 # for as many columns as desired; `CSV.detect(row, i)` can also be used to
 # use the same inference logic used in `CSV.File` for determing a cell's typed value
-struct Rows{transpose, IO, customtypes, V, stringtype}
+struct Rows{IO, customtypes, V, stringtype}
     name::String
     names::Vector{Symbol} # only includes "select"ed columns
     columns::Vector{Column}
@@ -134,7 +134,7 @@ function Rows(source::ValidSources;
             rm(x.file; force=true)
         end
     end
-    return Rows{ctx.transpose, typeof(ctx.buf), ctx.customtypes, eltype(values), ctx.stringtype}(
+    return Rows{typeof(ctx.buf), ctx.customtypes, eltype(values), ctx.stringtype}(
         ctx.name,
         ctx.names,
         ctx.columns,
@@ -188,7 +188,7 @@ Base.IteratorSize(::Type{<:Rows}) = Base.SizeUnknown()
     end
 end
 
-function checkwidencolumns!(r::Rows{t, ct, V}, cols) where {t, ct, V}
+function checkwidencolumns!(r::Rows{ct, V}, cols) where {ct, V}
     if cols > length(r.values)
         # we widened while parsing this row, need to widen other supporting objects
         for i = (length(r.values) + 1):cols
@@ -202,9 +202,9 @@ function checkwidencolumns!(r::Rows{t, ct, V}, cols) where {t, ct, V}
     return
 end
 
-@inline function Base.iterate(r::Rows{transpose, IO, customtypes, V, stringtype}, (pos, len, row)=(r.datapos, r.len, 1)) where {transpose, IO, customtypes, V, stringtype}
+@inline function Base.iterate(r::Rows{IO, customtypes, V, stringtype}, (pos, len, row)=(r.datapos, r.len, 1)) where {IO, customtypes, V, stringtype}
     (pos > len || row > r.limit) && return nothing
-    pos = parserow(1, 1, r.numwarnings, r.ctx, r.buf, pos, len, 1, r.datarow + row - 2, r.columns, transpose, customtypes)
+    pos = parserow(1, 1, r.numwarnings, r.ctx, r.buf, pos, len, 1, r.datarow + row - 2, r.columns, customtypes)
     columns = r.columns
     cols = length(columns)
     checkwidencolumns!(r, cols)


### PR DESCRIPTION
The changes in files that are not precompile.jl are inference
improvements; mainly from inspecting results of `@code_typed`,
Cthulhu.jl, and SnoopCompile.jl. The changes in precompile.jl are from
comments from @TimHoly recommending that in our precompile process, we
can just call regular code instead needing to call `precompile` with
methods/arg types. I'm aware I don't understand all the details around
precompilation, method invalidation, etc. but unfortunately, I feel a
bit blocked with CSV.jl's precompilation. With the changes in #875, we
now see a fixed overhead of allocations when parsing due, I'm told, to
an issue in Base Julia
(https://github.com/JuliaLang/julia/issues/34055).