### PR TITLE
Support gzip compression when writing csv output

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -234,7 +234,6 @@ function write(sch::Tables.Schema, rows, file, opts;
         for row in rows
             writerow(buf, ref, len, io, sch, row, cols, opts)
         end
-        @show typeof(io)
         Base.write(io, resize!(buf, ref[] - 1))
     end
     return file
@@ -290,8 +289,8 @@ function with(f::Function, @nospecialize(io), append, compress)
     needtoclose = false
     if io isa Union{Base.TTY, Base.Pipe, Base.PipeEndpoint, Base.DevNull}
         # pass, can't seek these
-    elseif io isa IO && !append
-        _seekstart(io)
+    elseif io isa IO
+        !append && _seekstart(io)
     else
         io = open(io, append ? "a" : "w")
         needtoclose = true

--- a/test/write.jl
+++ b/test/write.jl
@@ -1,4 +1,4 @@
-using CSV, Dates, WeakRefStrings, Tables
+using CSV, Dates, WeakRefStrings, Tables, CodecZlib
 using FilePathsBase
 using FilePathsBase: /
 
@@ -336,5 +336,10 @@ const table_types = (
     @test String(take!(io)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"
     @test String(take!(io2)) == "col1,col2,col3\n1,4,7\n2,5,8\n3,6,9\n"
 
+    # compressed writing
+    io = IOBuffer()
+    CSV.write(io, default_table; compress=true)
+    ct = CSV.read(io, Tables.columntable)
+    @test ct == default_table
 
 end # @testset "CSV.write"


### PR DESCRIPTION
Implements #874. Allows user to pass `compress=true` to write the data
out using standard gzip compression.