### PR TITLE
Declare `isrowtable(::Rows) == true`

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -155,8 +155,7 @@ function Rows(source::ValidSources;
     )
 end
 
-Tables.rowtable(::Type{<:Rows}) = true
-Tables.rows(r::Rows) = r
+Tables.isrowtable(::Type{<:Rows}) = true
 Tables.schema(r::Rows) = Tables.Schema(r.names, [coltype(x) for x in view(r.columns, r.columnmap)])
 Base.eltype(::Rows) = Row2
 Base.IteratorSize(::Type{<:Rows}) = Base.SizeUnknown()


### PR DESCRIPTION
- The existing code seems to be a typo, as
  as `rowtable` should return a `Vector{NamedTuple}`
  not a `Bool`. So i suspect we meant to
  define `isrowtable` (not `rowtable`).
- if `isrowtable`, then we get `rows(x) === x` for free

This is just something i happened to see when reading this part of the code for another reason.
  