### PR TITLE
Refactor internal pooling mechanics

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ finaltype(::Type{NeedsTypeDetection}) = Missing
 coltype(col) = ifelse(col.anymissing, Union{finaltype(col.type), Missing}, finaltype(col.type))
 
 pooled(col) = col.pool == 1.0
-maybepooled(col) = 0.0 < col.pool < 1.0
+maybepooled(col) = 0.0 < col.pool
 
 function getpool(x::Real)::Float64
     if x isa Bool
@@ -101,7 +101,7 @@ function allocate!(columns, rowsguess)
         # if the type hasn't been detected yet, then column will get allocated
         # in the detect method while parsing
         if col.type !== NeedsTypeDetection
-            if pooled(col) || maybepooled(col) || (isnan(col.pool) && col.type isa StringTypes)
+            if maybepooled(col) && (col.type isa StringTypes || col.columnspecificpool)
                 col.column = allocate(Pooled, rowsguess)
                 if !isdefined(col, :refpool)
                     col.refpool = RefPool(col.type)


### PR DESCRIPTION
Fixes #888. One of the core issues is that we weren't "remembering",
when a column's type got detected, whether its pool value was a generic
pool value (like `pool=true`), or provided per-column. This is unique to
pooling, because we don't/can't really apply the pooling until we know
the column type, so it's usually post-context.

The proposal here adds another field `columnspecificpool`, which will
remember this property. The other big issue is that the pooling
mechanics have shifted around a bit throughout the recent internals
refactoring, so we were a little inconsistent in how we were handling
things overall.