### PR TITLE
Fix nonstandard type passed as single types and fix deprecations

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -265,39 +265,39 @@ end
     checkvaliddelim(delim)
     ignorerepeated && delim === nothing && throw(ArgumentError("auto-delimiter detection not supported when `ignorerepeated=true`; please provide delimiter like `delim=','`"))
     if lazystrings && !streaming
-        Base.depwarn("`lazystrings` keyword argument is deprecated; use `stringtype=PosLenString` instead", :Context)
+        @warn "`lazystrings` keyword argument is deprecated; use `stringtype=PosLenString` instead"
         stringtype = PosLenString
     end
     if tasks !== nothing
-        Base.depwarn("`tasks` keyword argument is deprecated; use `ntasks` instead", :Context)
+        @warn "`tasks` keyword argument is deprecated; use `ntasks` instead"
         ntasks = tasks
     end
     if ignoreemptylines !== nothing
-        Base.depwarn("`ignoreemptylines` keyword argument is deprecated; use `ignoreemptyrows` instead", :Context)
+        @warn "`ignoreemptylines` keyword argument is deprecated; use `ignoreemptyrows` instead"
         ignoreemptyrows = ignoreemptylines
     end
     if lines_to_check !== nothing
-        Base.depwarn("`lines_to_check` keyword argument is deprecated; use `rows_to_check` instead", :Context)
+        @warn "`lines_to_check` keyword argument is deprecated; use `rows_to_check` instead"
         rows_to_check = lines_to_check
     end
     if !isempty(missingstrings)
-        Base.depwarn("`missingstrings` keyword argument is deprecated; pass a `Vector{String}` to `missingstring` instead", :Context)
+        @warn "`missingstrings` keyword argument is deprecated; pass a `Vector{String}` to `missingstring` instead"
         missingstring = missingstrings
     end
     if dateformats !== nothing
-        Base.depwarn("`dateformats` keyword argument is deprecated; pass column date formats to `dateformat` keyword argument instead", :Context)
+        @warn "`dateformats` keyword argument is deprecated; pass column date formats to `dateformat` keyword argument instead"
         dateformat = dateformats
     end
     if datarow != -1
-        Base.depwarn("`datarow` keyword argument is deprecated; use `skipto` instead", :Context)
+        @warn "`datarow` keyword argument is deprecated; use `skipto` instead"
         skipto = datarow
     end
     if type !== nothing
-        Base.depwarn("`type` keyword argument is deprecated; a single type can be passed to `types` instead", :Context)
+        @warn "`type` keyword argument is deprecated; a single type can be passed to `types` instead"
         types = type
     end
     if threaded !== nothing
-        Base.depwarn("`threaded` keyword argument is deprecated; to avoid multithreaded parsing, pass `ntasks=1`", :Context)
+        @warn "`threaded` keyword argument is deprecated; to avoid multithreaded parsing, pass `ntasks=1`"
         ntasks = threaded ? Threads.nthreads() : 1
     end
     if header isa Integer
@@ -445,6 +445,9 @@ end
         checkinvalidcolumns(types, "types", ncols, names)
     else
         T = types === nothing ? (streaming ? Union{stringtype, Missing} : NeedsTypeDetection) : types
+        if nonstandardtype(T) !== Union{}
+            customtypes = tupcat(customtypes, nonstandardtype(T))
+        end
         columns = Vector{Column}(undef, ncols)
         for i = 1:ncols
             col = Column(T, options)

--- a/src/file.jl
+++ b/src/file.jl
@@ -648,6 +648,10 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
             pos, code = parsevalue!(Int64, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Int128
             pos, code = parsevalue!(Int128, buf, pos, len, row, rowoffset, i, col, ctx)
+        elseif type === Float16
+            pos, code = parsevalue!(Float16, buf, pos, len, row, rowoffset, i, col, ctx)
+        elseif type === Float32
+            pos, code = parsevalue!(Float32, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === Float64
             pos, code = parsevalue!(Float64, buf, pos, len, row, rowoffset, i, col, ctx)
         elseif type === InlineString1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,6 +69,8 @@ end
     if T === Union{} ||
        T isa StringTypes ||
        isinttype(T) ||
+       T === Float16 ||
+       T === Float32 ||
        T === Float64 ||
        T === Bool ||
        T === Date ||

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -671,4 +671,13 @@ f = CSV.File(@view(data[:]))
 @test length(f) == 2
 @test f.column_name == ["foobar", "bazbat"]
 
+# 901; nonstandard types passed via types=T
+f = CSV.File(IOBuffer("a,b,c\n1.2,3.4,5.6\n"); types=Float32)
+@test length(f) == 1
+@test NamedTuple(f[1]) === (a=Float32(1.2), b=Float32(3.4), c=Float32(5.6))
+
+f = CSV.File(IOBuffer("a,b,c\n1.2,3.4,5.6\n"); types=BigFloat)
+@test length(f) == 1
+@test f[1].a == BigFloat("1.2") && f[1].b == BigFloat("3.4") && f[1].c == BigFloat("5.6")
+
 end


### PR DESCRIPTION
Fixes #901. The core issue for OP was a nonstandard type (`Float32`) was
passed like `types=Float32`, and the code branch that handled a single
passed type didn't check if that type was nonstandard (we do a runtime
dynamic dispatch purposely for nonstandard types). The error was masked
however since by default Julia doesn't show deprecation warnings, which
led me to realize that using `Base.depwarn` isn't a great idea for
package deprecations that you _want_ users to see and transition away
from. I've hence changed all keyword arg deprecations to just use
`@warn` since we want it to be in your face and noisy.

The other change included here is treating `Float16` and `Float32` as
"standard" types. We won't detect them by default, though we could
perhaps consider applying `downcast` to more than just integer types,
but in terms of dynamic code compilation at runtime, we can include
inference/dispatchable call for these types basically for free.