### PR TITLE
Support CodeUnits as valid input for CSV.File/CSV.Rows

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -39,7 +39,8 @@ const DEFAULT_MAX_WARNINGS = 100
 const DEFAULT_MAX_INLINE_STRING_LENGTH = 32
 const TRUE_STRINGS = ["true", "True", "TRUE", "T", "1"]
 const FALSE_STRINGS = ["false", "False", "FALSE", "F", "0"]
-const ValidSources = Union{Vector{UInt8}, SubArray{UInt8, 1, Vector{UInt8}}, IO, Cmd, AbstractString, AbstractPath}
+const StringCodeUnits = Base.CodeUnits{UInt8, String}
+const ValidSources = Union{Vector{UInt8}, SubArray{UInt8, 1, Vector{UInt8}}, StringCodeUnits, IO, Cmd, AbstractString, AbstractPath}
 const MAX_INPUT_SIZE = Int64(2)^42
 const EMPTY_INT_ARRAY = Int64[]
 

--- a/src/file.jl
+++ b/src/file.jl
@@ -41,9 +41,10 @@ use `CSV.read(input, sink; kwargs...)` instead if the `CSV.File` intermediate ob
 The [`input`](@ref input) argument can be one of:
   * filename given as a string or FilePaths.jl type
   * a `Vector{UInt8}` or `SubArray{UInt8, 1, Vector{UInt8}}` byte buffer
+  * a `CodeUnits` object, which wraps a `String`, like `codeunits(str)`
+  * a csv-formatted string can also be passed like `IOBuffer(str)`
   * a `Cmd` or other `IO`
-  * a csv-formatted string can be passed like `IOBuffer(str)`
-  * a gzipped file, which will automatically be decompressed for parsing
+  * a gzipped file (or gzipped data in any of the above), which will automatically be decompressed for parsing
   * a `Vector` of any of the above, which will parse and vertically concatenate each source, returning a single, "long" `CSV.File`
 
 To read a csv file from a url, use the Downloads.jl stdlib or HTTP.jl package, where the resulting downloaded tempfile or `HTTP.Response` body can be passed like:

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -37,10 +37,14 @@ end
 
 Read a csv input returning a `CSV.Rows` object.
 
-The `source` argument can be one of:
+The [`input`](@ref input) argument can be one of:
   * filename given as a string or FilePaths.jl type
-  * an `AbstractVector{UInt8}` like a byte buffer or `codeunits(string)`
-  * an `IOBuffer`
+  * a `Vector{UInt8}` or `SubArray{UInt8, 1, Vector{UInt8}}` byte buffer
+  * a `CodeUnits` object, which wraps a `String`, like `codeunits(str)`
+  * a csv-formatted string can also be passed like `IOBuffer(str)`
+  * a `Cmd` or other `IO`
+  * a gzipped file (or gzipped data in any of the above), which will automatically be decompressed for parsing
+
 
 To read a csv file from a url, use the HTTP.jl package, where the `HTTP.Response` body can be passed like:
 ```julia

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -171,6 +171,8 @@ consumeBOM(buf, pos) = (length(buf) >= 3 && buf[pos] == 0xef && buf[pos + 1] == 
         return x, 1, length(x), tfile
     elseif x isa SubArray{UInt8, 1, Vector{UInt8}}
         return parent(x), first(x.indices[1]), last(x.indices[1]), tfile
+    elseif x isa StringCodeUnits
+        return unsafe_wrap(Vector{UInt8}, x.s), 1, length(x), tfile
     elseif x isa IOBuffer
         if x.data isa Vector{UInt8}
             return x.data, x.ptr, x.size, tfile

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -680,4 +680,9 @@ f = CSV.File(IOBuffer("a,b,c\n1.2,3.4,5.6\n"); types=BigFloat)
 @test length(f) == 1
 @test f[1].a == BigFloat("1.2") && f[1].b == BigFloat("3.4") && f[1].c == BigFloat("5.6")
 
+# 894
+f = CSV.File(codeunits("a,b,c\n1.2,3.4,5.6\n"))
+@test length(f) == 1
+@test NamedTuple(f[1]) === (a=1.2, b=3.4, c=5.6)
+
 end


### PR DESCRIPTION
Fixes #894. I believe this used to work because we made a copy of the
input `CodeUnits` object, which is fine, because we got a
`Vector{UInt8}` out of it, but not ideal since we made a copy. After
some research, I found that when you call `IOBuffer(str)`, it uses this
nifty little trick of calling `unsafe_wrap(Vector{UInt8}, str)` which is
then passed to `IOBuffer` as a way to convert a string to a
`Vector{UInt8}` without copying. We can utilize the same trick to
efficiently treat a string as a `Vector{UInt8}` while the Julia
internals takes care of tracking the true owner of the data as the
original string for us (thus avoiding any GC issues if we were to
naively call `unsafe_wrap(Array, pointer(str))` ourselves).