### PR TITLE
Try to ensure refpools are promoted between string/inlinestring

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -401,7 +401,8 @@ function multithreadpostparse(ctx, ntasks, pertaskcolumns, rows, rowchunkguess, 
             else
                 task_col.column = convert(SentinelVector{Float64}, task_col.column)
             end
-        elseif T !== T2 && T <: InlineString
+        elseif T !== T2 && (T <: InlineString || (T === String && T2 <: InlineString))
+            # promote to widest InlineString type
             if task_col.column isa Vector{UInt32}
                 task_col.refpool.refs = convert(Refs{T}, task_col.refpool.refs)
             else


### PR DESCRIPTION
Attempted fix at #907. I'm still trying to come up with a way to
reproduce the error, but this may be a missing check where a column type
is ultimately promoted to `String`, but some chunk may have parsed as a
smaller InlineString type and thus needs to be promoted to `String`.