### PR TITLE
Add `validate` keyword for disabling argument checks

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -96,7 +96,7 @@ function Base.iterate(x::Chunks, i=1)
     threaded = false
     ntasks = 1
     limit = typemax(Int64)
-    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.validate, x.ctx.streaming)
+    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.streaming)
     f = File(ctx, true)
     return f, i + 1
 end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -72,9 +72,11 @@ function Chunks(source::ValidSources;
     silencewarnings::Bool=false,
     maxwarnings::Int=DEFAULT_MAX_WARNINGS,
     debug::Bool=false,
-    parsingdebug::Bool=false)
+    parsingdebug::Bool=false,
+    validate=true,
+    )
 
-    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, validate, false)
     !ctx.threaded && throw(ArgumentError("unable to iterate chunks from input file source"))
     foreach(col -> col.lock = ReentrantLock(), ctx.columns)
     return Chunks(ctx)
@@ -94,7 +96,7 @@ function Base.iterate(x::Chunks, i=1)
     threaded = false
     ntasks = 1
     limit = typemax(Int64)
-    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.streaming)
+    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.validate, x.ctx.streaming)
     f = File(ctx, true)
     return f, i + 1
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -104,9 +104,9 @@ end
 function checkinvalidcolumns(dict, argname, ncols, names)
     for (k, _) in dict
         if k isa Integer
-            (0 < k <= ncols) || throw(ArgumentError("invalid column number provided in `$argname` keyword argument: $k. Column number must be 0 < i <= $ncols as detected in the data"))
+            (0 < k <= ncols) || throw(ArgumentError("invalid column number provided in `$argname` keyword argument: $k. Column number must be 0 < i <= $ncols as detected in the data. To ignore invalid columns numbers in `$argname`, pass `validate=false`"))
         else
-            Symbol(k) in names || throw(ArgumentError("invalid column name provided in `$argname` keyword argument: $k. Valid column names detected in the data are: $names"))
+            Symbol(k) in names || throw(ArgumentError("invalid column name provided in `$argname` keyword argument: $k. Valid column names detected in the data are: $names. To ignore invalid columns names in `$argname`, pass `validate=false`"))
         end
     end
     return
@@ -140,6 +140,7 @@ struct Context
     maxwarnings::Int
     debug::Bool
     tempfile::Union{String, Nothing}
+    validate::Bool
     streaming::Bool
 end
 
@@ -193,9 +194,10 @@ function Context(source::ValidSources;
     silencewarnings::Bool=false,
     maxwarnings::Int=DEFAULT_MAX_WARNINGS,
     debug::Bool=false,
-    parsingdebug::Bool=false
+    parsingdebug::Bool=false,
+    validate::Bool=true,
     )
-    return @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
+    return @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, validate, false)
 end
 
 @refargs function Context(source::ValidSources,
@@ -247,6 +249,7 @@ end
     maxwarnings::Integer,
     debug::Bool,
     parsingdebug::Bool,
+    validate::Bool,
     streaming::Bool)
 
     # initial argument validation and adjustment
@@ -442,7 +445,7 @@ end
                 customtypes = tupcat(customtypes, nonstandardtype(col.type))
             end
         end
-        checkinvalidcolumns(types, "types", ncols, names)
+        validate && checkinvalidcolumns(types, "types", ncols, names)
     elseif types isa Function
         defaultT = streaming ? Union{stringtype, Missing} : NeedsTypeDetection
         columns = Vector{Column}(undef, ncols)
@@ -490,7 +493,7 @@ end
                 columns[i].options = Parsers.Options(sentinel, wh1, wh2, oq, cq, eq, d, decimal, trues, falses, df, ignorerepeated, ignoreemptyrows, comment, true, parsingdebug)
             end
         end
-        checkinvalidcolumns(dateformat, "dateformat", ncols, names)
+        validate && checkinvalidcolumns(dateformat, "dateformat", ncols, names)
     end
 
     # pool keyword
@@ -512,7 +515,7 @@ end
                     col.columnspecificpool = true
                 end
             end
-            checkinvalidcolumns(pool, "pool", ncols, names)
+            validate && checkinvalidcolumns(pool, "pool", ncols, names)
         elseif pool isa Base.Callable
             for i = 1:ncols
                 col = columns[i]
@@ -668,6 +671,7 @@ end
         maxwarnings,
         debug,
         tempfile,
+        validate,
         streaming
     )
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -140,7 +140,6 @@ struct Context
     maxwarnings::Int
     debug::Bool
     tempfile::Union{String, Nothing}
-    validate::Bool
     streaming::Bool
 end
 
@@ -671,7 +670,6 @@ end
         maxwarnings,
         debug,
         tempfile,
-        validate,
         streaming
     )
 end

--- a/src/file.jl
+++ b/src/file.jl
@@ -208,7 +208,8 @@ function File(source::ValidSources;
     silencewarnings::Bool=false,
     maxwarnings::Int=DEFAULT_MAX_WARNINGS,
     debug::Bool=false,
-    parsingdebug::Bool=false
+    parsingdebug::Bool=false,
+    validate::Bool=true,
     )
     # header=1;normalizenames=false;datarow=-1;skipto=-1;footerskip=0;transpose=false;comment=nothing;ignoreemptyrows=true;ignoreemptylines=nothing;
     # select=nothing;drop=nothing;limit=nothing;threaded=nothing;ntasks=Threads.nthreads();tasks=nothing;rows_to_check=30;lines_to_check=nothing;missingstrings=String[];missingstring="";
@@ -216,7 +217,7 @@ function File(source::ValidSources;
     # dateformats=nothing;decimal=UInt8('.');truestrings=nothing;falsestrings=nothing;type=nothing;types=nothing;typemap=Dict{Type,Type}();
     # pool=CSV.DEFAULT_POOL;downcast=false;lazystrings=false;stringtype=String;strict=false;silencewarnings=false;maxwarnings=100;debug=false;parsingdebug=false;buffer_in_memory=false
     # @descend CSV.Context(CSV.Arg(source), CSV.Arg(header), CSV.Arg(normalizenames), CSV.Arg(datarow), CSV.Arg(skipto), CSV.Arg(footerskip), CSV.Arg(transpose), CSV.Arg(comment), CSV.Arg(ignoreemptyrows), CSV.Arg(ignoreemptylines), CSV.Arg(select), CSV.Arg(drop), CSV.Arg(limit), CSV.Arg(buffer_in_memory), CSV.Arg(threaded), CSV.Arg(ntasks), CSV.Arg(tasks), CSV.Arg(rows_to_check), CSV.Arg(lines_to_check), CSV.Arg(missingstrings), CSV.Arg(missingstring), CSV.Arg(delim), CSV.Arg(ignorerepeated), CSV.Arg(quoted), CSV.Arg(quotechar), CSV.Arg(openquotechar), CSV.Arg(closequotechar), CSV.Arg(escapechar), CSV.Arg(dateformat), CSV.Arg(dateformats), CSV.Arg(decimal), CSV.Arg(truestrings), CSV.Arg(falsestrings), CSV.Arg(type), CSV.Arg(types), CSV.Arg(typemap), CSV.Arg(pool), CSV.Arg(downcast), CSV.Arg(lazystrings), CSV.Arg(stringtype), CSV.Arg(strict), CSV.Arg(silencewarnings), CSV.Arg(maxwarnings), CSV.Arg(debug), CSV.Arg(parsingdebug), CSV.Arg(false))
-    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, false)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, threaded, ntasks, tasks, rows_to_check, lines_to_check, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, validate, false)
     return File(ctx)
 end
 

--- a/src/keyworddocs.jl
+++ b/src/keyworddocs.jl
@@ -40,6 +40,7 @@ const KEYWORD_DOCS = """
   * `silencewarnings::Bool=false`: if `strict=false`, whether invalid value warnings should be silenced
   * `maxwarnings::Int=$DEFAULT_MAX_WARNINGS`: if more than `maxwarnings` number of warnings are printed while parsing, further warnings will be silenced by default; for multithreaded parsing, each parsing task will print up to `maxwarnings`
   * `debug::Bool=false`: passing `true` will result in many informational prints while a dataset is parsed; can be useful when reporting issues or figuring out what is going on internally while a dataset is parsed
+  * `validate::Bool=true`: whether or not to validate that columns specified in the `types`, `dateformat` and `pool` keywords are actually found in the data. If `false` no validation is done, meaning no error will be thrown if `types`/`dateformat`/`pool` specify settings for columns not actually found in the data.
 
 ## Iteration options:
 

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -117,9 +117,10 @@ function Rows(source::ValidSources;
     maxwarnings::Int=100,
     debug::Bool=false,
     parsingdebug::Bool=false,
+    validate::Bool=true,
     reusebuffer::Bool=false,
     )
-    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, nothing, nothing, 0, nothing, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, true)
+    ctx = @refargs Context(source, header, normalizenames, datarow, skipto, footerskip, transpose, comment, ignoreemptyrows, ignoreemptylines, select, drop, limit, buffer_in_memory, nothing, nothing, nothing, 0, nothing, missingstrings, missingstring, delim, ignorerepeated, quoted, quotechar, openquotechar, closequotechar, escapechar, dateformat, dateformats, decimal, truestrings, falsestrings, type, types, typemap, pool, downcast, lazystrings, stringtype, strict, silencewarnings, maxwarnings, debug, parsingdebug, validate, true)
     foreach(col -> col.pool = 0.0, ctx.columns)
     allocate!(ctx.columns, 1)
     values = all(x->x.type === ctx.stringtype && x.anymissing, ctx.columns) && ctx.stringtype === PosLenString ? Vector{PosLen}(undef, ctx.cols) : Vector{Any}(undef, ctx.cols)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -657,6 +657,15 @@ row = first(CSV.Rows(IOBuffer("a,b,c\n1,2,3\n\n"); select=[:a, :c]))
 @test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict(:d => true))
 @test_throws ArgumentError CSV.File(IOBuffer("a,b,c\n1,2,3"); pool=Dict("d" => true))
 
+# 910; disable checking of invalid columns passed in types/dateformat/pool keyword arguments
+@test (@test_logs CSV.File(
+    IOBuffer("a,b,c\n1,2,3");
+    types=Dict(4 => Float64),
+    dateformat=Dict(:e => "dd/mm/yyyy"),
+    pool=Dict("f" => true),
+    validate=false
+)) isa CSV.File
+
 # 871
 
 f = CSV.File(IOBuffer("a,b,c\n1,2,3\n3.14,5,6\n"); typemap=Dict(Float64 => String))


### PR DESCRIPTION
Closes #910, follow-up to #870

- Not sure if we want to support this via yet another keyword, but if we do i think this is roughly how to do it
- Also not sure how this works with `Rows`... it seems right now there's only validation for `File` and not for `Rows`. Is that intended? and if so how's best to document this?
- And definitely not sure about the best name (`validate`? `checkargs`?  `checkcols`? ...?)