### PR TITLE
Ensure tempfile for compressed input is removed when uncompressed

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -290,7 +290,13 @@ function getsource(@nospecialize(x), buffer_in_memory)
         if buffer_in_memory
             buf = transcode(GzipDecompressor, buf)
         else
+            # 917; if we already buffered input to tempfile, make sure the compressed tempfile is
+            # cleaned up since we're only passing the *uncompressed* tempfile up for removal post-parsing
+            tfile1 = tfile === nothing ? nothing : tfile
             buf, tfile = buffer_to_tempfile(GzipDecompressor(), IOBuffer(buf))
+            if tfile1 !== nothing
+                rm(tfile1; force=true)
+            end
         end
         pos = 1
         len = length(buf)

--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -110,16 +110,16 @@ testfiles = [
         (col1 = [1, 4, 7], col2 = [2, 5, 8], col3 = [3, 6, 9])
     ),
     # 418
-    # ("test_footer_missing.csv", NamedTuple(),
-    #     (5, 3),
-    #     NamedTuple{(:col1, :col2, :col3), Tuple{Union{Missing, Int64}, Union{Missing, Int64}, Union{Missing, Int64}}},
-    #     (col1 = Union{Missing, Int64}[1, 4, 7, 10, missing], col2 = Union{Missing, Int64}[2, 5, 8, 11, missing], col3 = Union{Missing, Int64}[3, 6, 9, 12, missing])
-    # ),
-    # ("test_footer_missing.csv", (footerskip=1,),
-    #     (4, 3),
-    #     NamedTuple{(:col1, :col2, :col3), Tuple{Int64, Int64, Int64}},
-    #     (col1 = [1, 4, 7, 10], col2 = [2, 5, 8, 11], col3 = [3, 6, 9, 12])
-    # ),
+    ("test_footer_missing.csv", NamedTuple(),
+        (5, 3),
+        NamedTuple{(:col1, :col2, :col3), Tuple{Union{Missing, Int64}, Union{Missing, Int64}, Union{Missing, Int64}}},
+        (col1 = Union{Missing, Int64}[1, 4, 7, 10, missing], col2 = Union{Missing, Int64}[2, 5, 8, 11, missing], col3 = Union{Missing, Int64}[3, 6, 9, 12, missing])
+    ),
+    ("test_footer_missing.csv", (footerskip=1,),
+        (4, 3),
+        NamedTuple{(:col1, :col2, :col3), Tuple{Int64, Int64, Int64}},
+        (col1 = [1, 4, 7, 10], col2 = [2, 5, 8, 11], col3 = [3, 6, 9, 12])
+    ),
     ("test_dates.csv", NamedTuple(),
         (3, 1),
         NamedTuple{(:col1,), Tuple{Date}},


### PR DESCRIPTION
As astutely discovered in #917, when the input was an IO/Cmd or some
other input, we first buffered input to a tempfile, then if we
discovered the contents of this tempfile were compressed, we would
uncompress the contents to a 2nd tempfile, which was kept track of and
removed at the end of parsing. The issue is the 1st tempfile of
compressed input was forgotten and not property cleaned up (except when
the final process was closed as per `mktemp` defaults).

Unfortunately it's not straightforward to try and "merge" the two
tempfile bufferings since there's no guaranteed interface for peeking a
the first 2 bytes of an IO/Cmd to rely on to detect compression.