### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CSV"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"


### PR DESCRIPTION
Seems like registrator was triggered for v0.9.6 before v0.9.5 was merged

so now v0.9.5 is out, we just need to bump the version and re-trigger registrator

- v0.9.5 was tagged/released already on an earlier commit 
  - https://github.com/JuliaData/CSV.jl/commit/549b1ab03155c8c96485406881addcc65ef914e8
  - https://github.com/JuliaRegistries/General/pull/45889
- v0.9.6 then failed to be tagged/released (because v0.9.5 wasn't in yet) 
  - we tried to tag it here https://github.com/JuliaData/CSV.jl/commit/69dd7b956a062ea16ce8063de8d7df309d4e17c1
  - but it failed https://github.com/JuliaRegistries/General/pull/45887
  
(v0.9.5 doesn't have #911, which someone on JuliaLang slack was asking about)