### PR TITLE
Fix macro hygiene issue in CSV.Rows for custom types

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -210,11 +210,11 @@ function checkwidencolumns!(r::Rows{ct, V}, cols) where {ct, V}
     return
 end
 
-macro unrollcolumns(setmissing, ex)
+macro unrollcolumns(setmissing, values, ex)
     return esc(quote
         if column isa MissingVector
             if !($setmissing)
-                @inbounds values[i] = missing
+                @inbounds $(values)[i] = missing
             end
         elseif column isa Vector{PosLen}
             $ex
@@ -263,7 +263,7 @@ macro unrollcolumns(setmissing, ex)
         elseif column isa Vector{UInt32}
             $ex
         elseif customtypes !== Tuple{}
-            setcustom!(customtypes, values, columns, i, $setmissing)
+            setcustom!(customtypes, $values, columns, i, $setmissing)
         else
             error("bad array type: $(typeof(column))")
         end
@@ -276,7 +276,7 @@ end
     cols = length(columns)
     for i = 1:cols
         @inbounds column = columns[i].column
-        @unrollcolumns true begin
+        @unrollcolumns true nothing begin
             setmissing!(column, 1)
         end
     end
@@ -286,7 +286,7 @@ end
     checkwidencolumns!(r, cols)
     for i = 1:cols
         @inbounds column = columns[i].column
-        @unrollcolumns false begin
+        @unrollcolumns false values begin
             @inbounds values[i] = column[1]
         end
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -705,4 +705,19 @@ f = CSV.File(codeunits("a,b,c,d\n1,2,3.14,hey\n4,2,6.5,hey\n");
 @test f.c == [3.14, 6.5]
 @test f.d == ["hey", "hey"]
 
+# 929
+str = """id,pos_1,pos_2,pos_3,has_prisoner,capture_time,shape
+5,11,86,1,false,0,diamond
+4,5,43,1,false,0,diamond
+6,16,90,1,false,0,diamond
+7,75,35,1,false,0,diamond
+2,35,89,1,false,0,diamond
+10,81,25,1,false,0,diamond
+9,48,98,1,false,0,diamond
+8,98,62,1,false,0,diamond
+3,50,2,1,false,0,diamond
+1,95,24,1,false,0,diamond"""
+r = collect(CSV.Rows(IOBuffer(str); types=Dict(:shape => Symbol)))
+@test length(r) == 10
+
 end


### PR DESCRIPTION
Fixes #929. I admit I don't fully understand what exactly is going wrong
here, but it seems that using the `@unrollcolumns` macro inside the `for
i = 1:cols` loop is somehow getting lost when it tries to reference the
`values` array from the unrolled macro block. I know there have been
various issues like this raised at JuliaLang/julia, but it's easy enough
for us to just pass in `values` an explicit argument to the macro, so
that seems an easy enough work-around for now.