### PR TITLE
Ensure dropped columns have type set as missing

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,12 @@
 # but in HardMissing case, we don't; we know the column will *always* be Missing
 struct HardMissing end
 
-willdrop!(columns, i) = setfield!(@inbounds(columns[i]), :willdrop, true)
+function willdrop!(columns, i)
+    @inbounds col = columns[i]
+    col.willdrop = true
+    col.type = HardMissing
+    return
+end
 
 struct NeedsTypeDetection end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -732,6 +732,7 @@ Jack, 12
 Tom, 10
 """
 f = CSV.File(IOBuffer(data); select=[2], type=Int32)
-
+@test length(f) == 2
+@test length(f.names) == 1
 
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -725,4 +725,13 @@ f = CSV.File(joinpath(dir, "multithreadedpromote.csv"))
 @test eltype(f.col1) == String7
 @test length(f) == 5001
 
+# 942
+data = """
+name, age
+Jack, 12
+Tom, 10
+"""
+f = CSV.File(IOBuffer(data); select=[2], type=Int32)
+
+
 end


### PR DESCRIPTION
Fixes #942. When dropping columns while parsing via `select` or `drop`,
we need to ensure the column type gets set as `HardMissing`.