### PR TITLE
Avoid promoting inline string types larger than String31

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -869,9 +869,9 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
                         code = trytopromote!(type, newT, buf, pos, len, col, row)
                         newT = _widen(newT)
                     end
-                elseif type === InlineString1 || type === InlineString3 || type === InlineString7 || type === InlineString15 || type === InlineString31 || type === InlineString63 || type === InlineString127
+                elseif type === InlineString1 || type === InlineString3 || type === InlineString7 || type === InlineString15
                     newT = widen(type)
-                    while newT !== InlineString127
+                    while newT !== InlineString63
                         ret = _parseany(newT, buf, pos, len, opts)
                         if !Parsers.invalid(ret.code)
                             col.type = newT

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -743,4 +743,9 @@ f = CSV.File(IOBuffer(data); header=false, types=Dict(1 => String), typemap=Dict
 f = CSV.File(IOBuffer(data); header=false, types=Dict(1 => String), downcast=true);
 @test f.types == [i == 1 ? String : Int8 for i = 1:60_000]
 
+# 948
+f = CSV.File(IOBuffer("a,b\n1,2\n3,"))
+@test f.a == [1, 3]
+@test isequal(f.b, [2, missing])
+
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -231,7 +231,7 @@ f = CSV.File(IOBuffer("x\n1\n$(typemax(Int16))\n$(typemax(Int32))\n$(typemax(Int
 @test eltype(f.x) === Float64
 
 f = CSV.File(IOBuffer("x\n1\n$(typemax(Int16))\n$(typemax(Int32))\n$(typemax(Int64))\n$(typemax(Int128))\n3.14\nabc"), downcast=true, ignoreemptyrows=true)
-@test eltype(f.x) === InlineString63
+@test eltype(f.x) === String
 
 f = CSV.File(IOBuffer("x\n\n1"), downcast=true, ignoreemptyrows=false)
 @test eltype(f.x) === Union{Missing, Int8}
@@ -478,7 +478,7 @@ f = CSV.File(IOBuffer("1,2\r\n3,4\r\n\r\n5,6\r\n"); header=["col1", "col2"], ign
 
 f = CSV.File(joinpath(dir, "escape_row_starts.csv"); ntasks=2)
 @test length(f) == 10000
-@test eltype(f.col1) == InlineString63
+@test eltype(f.col1) == String
 @test eltype(f.col2) == Int
 
 f = CSV.File(IOBuffer("col1\nhey\nthere\nsailor"); stringtype=PosLenString)

--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -273,7 +273,7 @@ testfiles = [
     # other various files from around the interwebs
     ("baseball.csv", (pool=true, normalizenames=true),
         (35, 15),
-        NamedTuple{(:Rk, :Year, :Age, :Tm, :Lg, :Column6, :W, :L, :W_L_, :G, :Finish, :Wpost, :Lpost, :W_L_post, :Column15), Tuple{Union{Int, Missing},Union{Int, Missing},Union{Int, Missing},Union{InlineString31, Missing},Union{InlineString3, Missing},Union{InlineString15, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{InlineString63, Missing}}},
+        NamedTuple{(:Rk, :Year, :Age, :Tm, :Lg, :Column6, :W, :L, :W_L_, :G, :Finish, :Wpost, :Lpost, :W_L_post, :Column15), Tuple{Union{Int, Missing},Union{Int, Missing},Union{Int, Missing},Union{InlineString31, Missing},Union{InlineString3, Missing},Union{InlineString15, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Float64, Missing},Union{Int, Missing},Union{Int, Missing},Union{Float64, Missing},Union{String, Missing}}},
         nothing
     ),
     ("FL_insurance_sample.csv", (pool=true,),
@@ -293,12 +293,12 @@ testfiles = [
     ),
     ("SalesJan2009.csv", (pool=true,),
         (998, 12),
-        NamedTuple{(:Transaction_date, :Product, :Price, :Payment_Type, :Name, :City, :State, :Country, :Account_Created, :Last_Login, :Latitude, :Longitude),Tuple{InlineString15,InlineString15,InlineString7,InlineString15,InlineString31,InlineString63,Union{Missing, InlineString31},InlineString31,InlineString15,InlineString15,Float64,Float64}},
+        NamedTuple{(:Transaction_date, :Product, :Price, :Payment_Type, :Name, :City, :State, :Country, :Account_Created, :Last_Login, :Latitude, :Longitude),Tuple{InlineString15,InlineString15,InlineString7,InlineString15,InlineString31,String,Union{Missing, InlineString31},InlineString31,InlineString15,InlineString15,Float64,Float64}},
         nothing
     ),
     ("stocks.csv", (normalizenames=true,),
         (30, 2),
-        NamedTuple{(:Stock_Name, :Company_Name), Tuple{InlineString7, InlineString63}},
+        NamedTuple{(:Stock_Name, :Company_Name), Tuple{InlineString7, String}},
         nothing
     ),
     ("TechCrunchcontinentalUSA.csv", (pool=true, stringtype=String),
@@ -623,7 +623,7 @@ testfiles = [
     # https://github.com/JuliaData/CSV.jl/issues/577
     ("csv_segfault.txt", (delim="\t", ignoreemptyrows=true),
         (468, 9),
-        NamedTuple{(Symbol("Time (CEST)"), :Latitude, :Longitude, :Course, :kts, :mph, :feet, :Rate, Symbol("Reporting Facility")),Tuple{InlineString63, Union{Missing, InlineString15}, Union{Missing, InlineString15}, Union{Missing, InlineString31}, Union{Missing, InlineString3}, Union{Missing, InlineString3}, Union{Missing, InlineString7}, Union{Missing, InlineString31}, Union{Missing, InlineString31}}},
+        NamedTuple{(Symbol("Time (CEST)"), :Latitude, :Longitude, :Course, :kts, :mph, :feet, :Rate, Symbol("Reporting Facility")),Tuple{String, Union{Missing, InlineString15}, Union{Missing, InlineString15}, Union{Missing, InlineString31}, Union{Missing, InlineString3}, Union{Missing, InlineString3}, Union{Missing, InlineString7}, Union{Missing, InlineString31}, Union{Missing, InlineString31}}},
         nothing
     ),
     # https://github.com/JuliaData/CSV.jl/issues/575
@@ -644,7 +644,7 @@ testfiles = [
     # https://github.com/JuliaData/CSV.jl/issues/597
     push!(testfiles, ("ampm.csv", (dateformat="m/d/yyyy I:M:S p",),
         (2, 16),
-        NamedTuple{(:ID, :INTERLOCK_NUMBER, :INTERLOCK_DESCRIPTION, :TYPE, :CREATE_DATE, :MODIFY_DATE, :USERNAME, :UNIT, :AREA, :PURPOSE, :PID, :LOCATION, :FUNC_DATE, :FUNC_BY, :TECHNICAL_DESCRIPTION, :types), Tuple{Int, Union{Missing, InlineString15}, InlineString63, Missing, DateTime, DateTime, InlineString15, InlineString15, InlineString15, InlineString31, Missing, Missing, DateTime, Missing, InlineString63, InlineString3}},
+        NamedTuple{(:ID, :INTERLOCK_NUMBER, :INTERLOCK_DESCRIPTION, :TYPE, :CREATE_DATE, :MODIFY_DATE, :USERNAME, :UNIT, :AREA, :PURPOSE, :PID, :LOCATION, :FUNC_DATE, :FUNC_BY, :TECHNICAL_DESCRIPTION, :types), Tuple{Int, Union{Missing, InlineString15}, String, Missing, DateTime, DateTime, InlineString15, InlineString15, InlineString15, InlineString31, Missing, Missing, DateTime, Missing, String, InlineString3}},
         x -> @test x.CREATE_DATE == [DateTime("2012-02-09T00:00:00"), DateTime("1998-07-22T16:37:01")]
     ))
     nothing


### PR DESCRIPTION
Fixes #945. The core issue here is an inconsistency between the initial
type detection code and the later-on type promotion code while parsing.
The type detection code had a limit setup so that inline string column
types weren't allowed larger than `String31`. The promotion code,
however, allowed inline string types to continue to promote up to
`String255`. That means if a column type was at least initiall detected
as some smaller-than-`String31` type, then later on a value larger than
31 bytes was parsed, it would continue to promote up to larger inline
string types. The change proposed in this PR is to limit the promotion
code to be more consistent with the type detection code: if a parsed
value "overflows" the `String31` type, we'll just promote to a regular
`String` instead of promoting to larger inline string types.