### PR TITLE
Fix use of limit in multithreaded parsing

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -250,11 +250,15 @@ function File(ctx::Context, @nospecialize(chunking::Bool=false))
                     # need to resize this tasks columns down
                     if finalrows - acc > 0
                         for col in pertaskcolumns[i]
-                            resize!(col.column, finalrows - acc)
+                            if isdefined(col, :column)
+                                resize!(col.column, finalrows - acc)
+                            end
                         end
                     else
                         for col in pertaskcolumns[i]
-                            empty!(col.column)
+                            if isdefined(col, :column)
+                                empty!(col.column)
+                            end
                         end
                     end
                 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -769,4 +769,8 @@ f = CSV.File(IOBuffer(data); delim='|', normalizenames=true, stripwhitespace=fal
 f = CSV.File(IOBuffer(data); delim='|', stripwhitespace=true)
 @test f.Name[2] == "Mary Anne"
 
+# 963
+f = CSV.File(IOBuffer(join((rand(("a,$(rand())", "b,$(rand())")) for _ = 1:10^6), "\n")), header=false, limit=10000)
+@test length(f) == 10000
+
 end


### PR DESCRIPTION
Fixes #963. The issue here is that although we were adjusting the # of
rows to a provided limit when multithreaded parsing, we failed to adjust
the actual column arrays to the correct size. This was an issue when we
converted from the old `CSV.Column` custom array type to returning
"normal" arrays in the 0.7 -> 0.8 transition. With `CSV.Column`, we just
passed the final row total and it adjusted the size dynamically, without
physically resizing the underlying array. With regular arrays, however,
we need to ensure the array gets resized appropriately. This became more
apparent in the recent pooling change that was released since it
actually became a silenced BoundsError because of the use of `@inbounds`
in the new `checkpooled!` routine. I've taken out those `@inbounds` uses
for now to be more conservative. The fix is fairly straightforward in
that if we adjust our final row down to a user-provided limit, then we
loop over the parsing tasks and "accumulate" rows until we hit the limit
and then resize or `empty!` columns as appropriate.