### PR TITLE
Allow more permissive string parsing

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -762,7 +762,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
     opts = col.options
     res = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
     code = res.code
-    if !Parsers.invalid(code)
+    if Parsers.valueok(code)
         if type !== Missing
             if Parsers.sentinel(code)
                 col.anymissing = true

--- a/src/file.jl
+++ b/src/file.jl
@@ -762,7 +762,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
     opts = col.options
     res = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
     code = res.code
-    if Parsers.valueok(code)
+    if (type === String && Parsers.valueok(code)) || !Parsers.invalid(code)
         if type !== Missing
             if Parsers.sentinel(code)
                 col.anymissing = true

--- a/src/file.jl
+++ b/src/file.jl
@@ -762,7 +762,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
     opts = col.options
     res = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
     code = res.code
-    if (type isa StringTypes && Parsers.valueok(code)) || !Parsers.invalid(code)
+    if (type === String && Parsers.valueok(code)) || !Parsers.invalid(code)
         if type !== Missing
             if Parsers.sentinel(code)
                 col.anymissing = true

--- a/src/file.jl
+++ b/src/file.jl
@@ -762,7 +762,7 @@ function parsevalue!(::Type{type}, buf, pos, len, row, rowoffset, i, col, ctx)::
     opts = col.options
     res = Parsers.xparse(type === Missing ? String : type, buf, pos, len, opts)
     code = res.code
-    if (type === String && Parsers.valueok(code)) || !Parsers.invalid(code)
+    if (type isa StringTypes && Parsers.valueok(code)) || !Parsers.invalid(code)
         if type !== Missing
             if Parsers.sentinel(code)
                 col.anymissing = true

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -773,4 +773,8 @@ f = CSV.File(IOBuffer(data); delim='|', stripwhitespace=true)
 f = CSV.File(IOBuffer(join((rand(("a,$(rand())", "b,$(rand())")) for _ = 1:10^6), "\n")), header=false, limit=10000)
 @test length(f) == 10000
 
+# 972
+f = CSV.File(joinpath(dir, "rdatasets.csv"))
+@test length(f) == 2
+
 end

--- a/test/testfiles/rdatasets.csv
+++ b/test/testfiles/rdatasets.csv
@@ -1,0 +1,3 @@
+"Package","Dataset","Title","Rows","Columns"
+"HistData","GaltonFamilies","Galton's data on the heights of parents and their children, by child",934,8
+"HistData","Guerry","Data from A.-M. Guerry, \"Essay on the Moral Statistics of France\"",86,23


### PR DESCRIPTION
- Set the value if we have `valueok` rather
  than relying on `!invalid`, to avoid erroring
  when we have successfully parsed a string but
  then hit an invalid delimiter.
- Fixes #972.

I don't actually see why `"Data from A.-M. Guerry, \"Essay on the Moral Statistics of France\""` is getting parsed only as `Data from A.-M. Guerry, `, but it is even with prior versions of CSV (e.g. v0.8) and Parsers (e.g. v1), so this PR just restores the behaviour we had with Parsers v2.2.0, but which broke when we started marking such cases as invalid in Parsers v2.2.1

cc @quinnj @andreasnoack 