### PR TITLE
remove init and precompile

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -91,14 +91,4 @@ function read(source, sink=nothing; copycols::Bool=false, kwargs...)
     Tables.CopiedColumns(CSV.File(source; kwargs...)) |> sink
 end
 
-include("precompile.jl")
-_precompile_()
-
-function __init__()
-    CSV.Context(IOBuffer(CSV.PRECOMPILE_DATA))
-    # CSV.File(IOBuffer(CSV.PRECOMPILE_DATA))
-    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    # CSV.File(joinpath(dirname(pathof(CSV)), "..", "test", "testfiles", "promotions.csv"))
-end
-
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,8 +1,0 @@
-const PRECOMPILE_DATA = "int,float,date,datetime,bool,null,str,catg,int_float\n1,3.14,2019-01-01,2019-01-01T01:02:03,true,,hey,abc,2\n2,NaN,2019-01-02,2019-01-03T01:02:03,false,,there,abc,3.14\n"
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    while false; end
-    # CSV.Context(IOBuffer(CSV.PRECOMPILE_DATA))
-    # foreach(row -> row, CSV.Rows(IOBuffer(PRECOMPILE_DATA)))
-    CSV.Context(joinpath(dirname(pathof(CSV)), "promotions.csv"))
-end


### PR DESCRIPTION
This is a much simpler PR than the last one, and gives quite a good TTFX improvment for no work.

The `__init__()` method here barely helps with `File` or `Context`, but costs a few seconds with `using`.

Perversely, on 1.7 `_precompile_()` actually makes the first load slower.

Removing them both gives a couple of seconds improvement in time to `using CSV; File(filename)`
