### PR TITLE
fix ccall usage on CSV 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CSV"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "0.5.26"
+version = "0.5.27"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -381,7 +381,7 @@ end
 
 function unset!(A::Vector, i::Int, row, x)
     finalize(A[i])
-    ccall(:jl_arrayunset, Cvoid, (Array, Csize_t), A, i - 1)
+    ccall(:jl_arrayunset, Cvoid, (Any, Csize_t), A, i - 1)
     # println("deleting col = $i on thread = $(Threads.threadid()), row = $row, id = $x")
     return
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -362,11 +362,13 @@ df = CSV.read(GzipDecompressorStream(open(joinpath(dir, "randoms.csv.gz"))))
 @test size(df) == (70000, 7)
 
 # int sentinel cycling
-import Random; Random.seed!(1234)
-df = CSV.read(joinpath(dir, "test_int_sentinel.csv"))
-@test df.id.sentinel == 0x6690d6bed2a7da46
-@test df.id[end] == CSV.INT_SENTINEL
-@test df.id[end-1] === missing
+if VERSION <= v"1.6.99" # RNG stream changed in 1.6
+    import Random; Random.seed!(1234)
+    df = CSV.read(joinpath(dir, "test_int_sentinel.csv"))
+    @test df.id.sentinel == 0x6690d6bed2a7da46
+    @test df.id[end] == CSV.INT_SENTINEL
+    @test df.id[end-1] === missing
+end
 
 Random.seed!(1234)
 df = CSV.read(joinpath(dir, "test_int_sentinel.csv"), threaded=true)

--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -5,14 +5,20 @@ function testfile(file, kwargs, expected_sz, expected_sch, testfunc; dir=dir)
     end
     rows = CSV.Rows(file isa IO ? file : joinpath(dir, file); kwargs...) |> columntable
     actual_sch = Tables.schema(rows)
-    @test Tuple(expected_sch.names) == actual_sch.names
+    datatype_has_fieldnames = :names in fieldnames(DataType)
+    if datatype_has_fieldnames
+        @test Tuple(expected_sch.names) == actual_sch.names
+    end
     if file isa IO
         seekstart(file)
     end
     t = CSV.File(file isa IO ? file : joinpath(dir, file); kwargs...) |> columntable
     actual_sch = Tables.schema(t)
+    datatype_has_fieldnames = :names in fieldnames(DataType)
     @test Tuple(expected_sch.types) == actual_sch.types
-    @test Tuple(expected_sch.names) == actual_sch.names
+    if datatype_has_fieldnames
+        @test Tuple(expected_sch.names) == actual_sch.names
+    end
     @test (length(t) == 0 ? 0 : length(t[1]), length(t)) == expected_sz
     if testfunc === nothing
     elseif testfunc isa Function


### PR DESCRIPTION
There are quite a few packages that are stuck on CSV 0.5 and it starts to error
on Julia 1.8 due to the faulty `ccall` usage here.

It would be good if a `release-0.5` branch could be created, this merged into it
and a new 0.5 release tagged from it.
