### PR TITLE
Expose user-facing versions of `CSV.writerow`

### DIFF
--- a/test/write.jl
+++ b/test/write.jl
@@ -355,4 +355,14 @@ end
     ct = CSV.read(io, Tables.columntable)
     @test ct == default_table
 
+    # CSV.writerow
+    row = (a=1, b=2.3, c="hey", d=Date(2022, 5, 4))
+    str = CSV.writerow(row)
+    @test str == "1,2.3,hey,2022-05-04\n"
+    io = IOBuffer()
+    CSV.writerow(io, row)
+    @test String(take!(io)) == "1,2.3,hey,2022-05-04\n"
+    str = CSV.writerow(row; delim='\t')
+    @test str == "1\t2.3\they\t2022-05-04\n"
+
 end # @testset "CSV.write"


### PR DESCRIPTION
Implements #1001. We already had the internal methods here, so this PR just adds some higher-level user-facing methods that take a plain "row" (from the Tables.jl "Row" interface) or an `io` and row. This is convenient when you don't have a traditional iterator (and can use RowWriter), but just want to repeatedly call `CSV.writerow` yourself and get the delimited output.

cc: @sairus7