### PR TITLE
Show an example on top of `CSV.read`

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -82,6 +82,30 @@ include("write.jl")
 Read and parses a delimited file or files, materializing directly using the `sink` function. Allows avoiding excessive copies
 of columns for certain sinks like `DataFrame`.
 
+# Example
+```
+julia> using CSV, DataFrames
+
+julia> path = tempname();
+
+julia> write(path, "a,b,c\\n1,2,3");
+
+julia> CSV.read(path, DataFrame)
+1×3 DataFrame
+ Row │ a      b      c
+     │ Int64  Int64  Int64
+─────┼─────────────────────
+   1 │     1      2      3
+
+julia> CSV.read(path, DataFrame; header=false)
+2×3 DataFrame
+ Row │ Column1  Column2  Column3
+     │ String1  String1  String1
+─────┼───────────────────────────
+   1 │ a        b        c
+   2 │ 1        2        3
+```
+
 $KEYWORD_DOCS
 """
 function read(source, sink=nothing; copycols::Bool=false, kwargs...)


### PR DESCRIPTION
I was looking through the documentation of this package and noticed that there is no example for `CSV.read`. Instead it just lists all the arguments. I suggest to add a small example which answers:

1. "How do I open a `CSV` file as a `DataFrame`?" since the majority of readers will be looking for this
2. "How do I pass one of these listed arguments to the `CSV.read` function?"

Maybe we can move the `CSV.read` also to the top of the page at <https://csv.juliadata.org/stable/reading.html>? That would make the information more consistent with the <https://csv.juliadata.org/stable/writing.html>. The writing page is excellent by the way. Very clear.

