### PR TITLE
Add links to alternatives to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 There are several other packages for reading CSV files in Julia, which may suit your needs better:
 
-* The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/),
-  which is perfect for quickly reading small files.
+* The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/).
+  This returns a `Matrix` rather than a [Tables.jl](https://github.com/JuliaData/Tables.jl)-style container, thus works best for files of homogenous element type. 
+  On large files, CSV.jl will be much faster.
 
 * [CSVFiles.jl](https://github.com/queryverse/CSVFiles.jl) uses the [FileIO.jl](https://github.com/JuliaIO/FileIO.jl) API 
   into any [IterableTables.jl](https://github.com/queryverse/IterableTables.jl) sink.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 There are several other packages for reading CSV files in Julia, which may suit your needs better:
 
-* The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/).
+* The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/), at least until Julia 1.8.
   This returns a `Matrix` rather than a [Tables.jl](https://github.com/JuliaData/Tables.jl)-style container, thus works best for files of homogenous element type. 
   On large files, CSV.jl will be much faster.
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [codecov-url]: https://codecov.io/gh/JuliaData/CSV.jl
 
 [issues-url]: https://github.com/JuliaData/CSV.jl/issues
+
+## Alternatives
+
+There are several other packages for reading CSV files in Julia, which may suit your needs better:
+
+* The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/),
+  which is perfect for quickly reading small files.
+
+* [DLMReader.jl](https://github.com/sl-solution/DLMReader.jl) also aims to be fast for large files. 
+  Closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl).
+
+Python and R also have CSV readers in the standard library. Fast packages include...
+

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ There are several other packages for reading CSV files in Julia, which may suit 
   into any [IterableTables.jl](https://github.com/queryverse/IterableTables.jl) sink.
   The package uses [TextParse.jl](https://github.com/queryverse/TextParse.jl) for parsing.
 
-* [DLMReader.jl](https://github.com/sl-solution/DLMReader.jl) also aims to be fast for large files. 
-  Closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl) rather than [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl)
+* [DLMReader.jl](https://github.com/sl-solution/DLMReader.jl) also aims to be fast for large files,
+  closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl).
 
-* [Pandas.jl](https://github.com/JuliaPy/Pandas.jl) wraps Python's pandas library, via PyCall.jl.
+* [Pandas.jl](https://github.com/JuliaPy/Pandas.jl) wraps Python's [pandas](https://pandas.pydata.org) library (using [PyCall.jl](https://github.com/JuliaPy/PyCall.jl)).
+  This is a closer cousin of [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl), but builds in the ability to read/write CSV files.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ There are several other packages for reading CSV files in Julia, which may suit 
 * The standard library contains [DelimitedFiles.jl](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/),
   which is perfect for quickly reading small files.
 
+* [CSVFiles.jl](https://github.com/queryverse/CSVFiles.jl) uses the [FileIO.jl](https://github.com/JuliaIO/FileIO.jl) API 
+  into any [IterableTables.jl](https://github.com/queryverse/IterableTables.jl) sink.
+  The package uses [TextParse.jl](https://github.com/queryverse/TextParse.jl) for parsing.
+
 * [DLMReader.jl](https://github.com/sl-solution/DLMReader.jl) also aims to be fast for large files. 
-  Closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl).
+  Closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl) rather than [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl)
 
-Python and R also have CSV readers in the standard library. Fast packages include...
-
+* [Pandas.jl](https://github.com/JuliaPy/Pandas.jl) wraps Python's pandas library, via PyCall.jl.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ There are several other packages for reading CSV files in Julia, which may suit 
   This returns a `Matrix` rather than a [Tables.jl](https://github.com/JuliaData/Tables.jl)-style container, thus works best for files of homogenous element type. 
   On large files, CSV.jl will be much faster.
 
-* [CSVFiles.jl](https://github.com/queryverse/CSVFiles.jl) uses the [FileIO.jl](https://github.com/JuliaIO/FileIO.jl) API 
-  into any [IterableTables.jl](https://github.com/queryverse/IterableTables.jl) sink.
-  The package uses [TextParse.jl](https://github.com/queryverse/TextParse.jl) for parsing.
+* [CSVFiles.jl](https://github.com/queryverse/CSVFiles.jl) uses the [FileIO.jl](https://github.com/JuliaIO/FileIO.jl)'s `load` / `save` API,
+  but otherwise has similar goals. Like CSV.jl, it works with [Tables.jl](https://github.com/JuliaData/Tables.jl objects such as DataFrames.
 
 * [DLMReader.jl](https://github.com/sl-solution/DLMReader.jl) also aims to be fast for large files,
   closely associated with [InMemoryDatasets.jl](https://github.com/sl-solution/InMemoryDatasets.jl).


### PR DESCRIPTION
As discussed here https://discourse.julialang.org/t/how-do-i-know-if-a-package-is-good/82133, it might be nice if this package linked to alternative ways to read CSV files. Really all packages should do this, but this one is what you find if you google "csv julia"... and I bet that many people googling that just want DelimitedFiles. 

I'm not really qualified to write the list of fancier alternatives, since DelimitedFiles does what I need right now. But @juliohm @sl-solution @chriselrod from discourse thread may have better ideas. And in particular about what most important differences should be mentioned.

I'm especially unqualified to list Python or R alternatives. That's less obviously necessary, but their names are terms people might search for. 

Xref https://github.com/JuliaPy/Pandas.jl/issues/87 about Pandas.jl -> DataFrames.jl.