### PR TITLE
Check for user-given type when encountering extra columns during parsing

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -97,7 +97,7 @@ function Base.iterate(x::Chunks, i=1)
     threaded = false
     ntasks = 1
     limit = typemax(Int)
-    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.streaming)
+    ctx = Context(x.ctx.transpose, x.ctx.name, names, rowsguess, x.ctx.cols, x.ctx.buf, datapos, len, 1, x.ctx.options, columns, x.ctx.pool, x.ctx.downcast, x.ctx.customtypes, x.ctx.typemap, x.ctx.stringtype, limit, threaded, ntasks, x.ctx.chunkpositions, x.ctx.strict, x.ctx.silencewarnings, x.ctx.maxwarnings, x.ctx.debug, x.ctx.tempfile, x.ctx.streaming, x.ctx.types)
     f = File(ctx, true)
     return f, i + 1
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -133,7 +133,9 @@ end
 
 function initialize_column(i, types::AbstractDict, names, stringtype, streaming::Bool, options)
     defaultT = streaming ? Union{stringtype, Missing} : NeedsTypeDetection
-    T = getordefault(types, names[i], i, defaultT)
+    # if an additional column is found while parsing, it will not have a name yet
+    nm = i <= length(names) ? names[i] : ""
+    T = getordefault(types, nm, i, defaultT)
     col = Column(T, options)
     return col
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -140,7 +140,9 @@ end
 
 function initialize_column(i, types::Function, names, stringtype, streaming::Bool, options)
     defaultT = streaming ? Union{stringtype, Missing} : NeedsTypeDetection
-    T = something(types(i, names[i]), defaultT)
+    # if an additional column is found while parsing, it will not have a name yet
+    nm = i <= length(names) ? names[i] : ""
+    T = something(types(i, nm), defaultT)
     return Column(T, options)
 end
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -134,9 +134,13 @@ function initialize_column(i, types::Function, names, stringtype, streaming::Boo
     return Column(T, options)
 end
 
-function initialize_column(i, types::Any, names, stringtype, streaming::Bool, options)
-    T = types === nothing ? (streaming ? Union{stringtype, Missing} : NeedsTypeDetection) : types
+function initialize_column(i, types::Nothing, names, stringtype, streaming::Bool, options)
+    T = streaming ? Union{stringtype, Missing} : NeedsTypeDetection
     return Column(T, options)
+end
+
+function initialize_column(i, types::Type, names, stringtype, streaming::Bool, options)
+    return Column(types, options)
 end
 
 struct Context

--- a/src/file.jl
+++ b/src/file.jl
@@ -684,17 +684,17 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
                 # extra columns on this row, let's widen
                 ctx.silencewarnings || toomanycolumns(ncols, rowoffset + row)
                 j = i + 1
-                T = ctx.streaming ? Union{ctx.stringtype, Missing} : NeedsTypeDetection
                 while pos <= len && !Parsers.newline(code)
-                    col = Column(T, ctx.options)
+                    col = initialize_column(j, ctx)
                     col.anymissing = ctx.streaming || rowoffset == 0 && row > 1 # assume all previous rows were missing
                     col.pool = ctx.pool
+                    T = col.type
                     if T === NeedsTypeDetection
                         pos, code = detectcell(buf, pos, len, row, rowoffset, j, col, ctx, rowsguess)
                     else
                         # need to allocate
-                        col.column = allocate(ctx.stringtype, ctx.rowsguess)
-                        pos, code = parsevalue!(ctx.stringtype, buf, pos, len, row, rowoffset, j, col, ctx)
+                        col.column = allocate(T, ctx.rowsguess)
+                        pos, code = parsevalue!(T, buf, pos, len, row, rowoffset, j, col, ctx)
                     end
                     j += 1
                     push!(columns, col)

--- a/src/file.jl
+++ b/src/file.jl
@@ -693,7 +693,7 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
                     # Right now if `T` is a `nonstandardtype` not already in `customtypes`, then
                     # we won't have a specialised parse method for it, so parsing is expected to fail.
                     # Only log the error, rather than throw, in case parsing somehow works.
-                    T in TYPES || T in ctx.customtypes.parameters || @error "Parsing extra column with unknown type `$T`. Parsing may fail!"
+                    nonstandardtype(T) === Union{} || T in ctx.customtypes.parameters || @error "Parsing extra column with unknown type `$T`. Parsing may fail!"
                     if T === NeedsTypeDetection
                         pos, code = detectcell(buf, pos, len, row, rowoffset, j, col, ctx, rowsguess)
                     else

--- a/src/file.jl
+++ b/src/file.jl
@@ -688,6 +688,7 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
                     col = initialize_column(j, ctx)
                     col.anymissing = ctx.streaming || rowoffset == 0 && row > 1 # assume all previous rows were missing
                     col.pool = ctx.pool
+                    # TODO: Do we need to check `nonstandardtype(T)` and potentially create a `Context` an updated `customtypes`?
                     T = col.type
                     if T === NeedsTypeDetection
                         pos, code = detectcell(buf, pos, len, row, rowoffset, j, col, ctx, rowsguess)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -812,5 +812,8 @@ f = CSV.File(IOBuffer(str); delim=" ", header=false, types=String)
 # case where `types isa AbstractVector`
 f = CSV.File(IOBuffer(str); delim=" ", header=false, types=[Int8, Int16, Int32, Int64, String])
 @test String <: eltype(f.Column5)
+# case where `types isa Function`
+f = CSV.File(IOBuffer(str); delim=" ", header=false, types=(i,nm) -> (i == 5 ? Int8 : String))
+@test Int8 <: eltype(f.Column5)
 
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -815,5 +815,8 @@ f = CSV.File(IOBuffer(str); delim=" ", header=false, types=[Int8, Int16, Int32, 
 # case where `types isa Function`
 f = CSV.File(IOBuffer(str); delim=" ", header=false, types=(i,nm) -> (i == 5 ? Int8 : String))
 @test Int8 <: eltype(f.Column5)
+# case where `types isa AbstractDict`
+f = CSV.File(IOBuffer(str); delim=" ", header=false, types=Dict(r".*" => Float16))
+@test Float16 <: eltype(f.Column5)
 
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -798,4 +798,19 @@ f = CSV.File(IOBuffer("time,date1,date2\n10:00:00.0,04/16/2020,04/17/2022\n"); d
 @test f[1].date1 == Dates.Date(2020, 4, 16)
 @test f[1].date2 == Dates.Date(2022, 4, 17)
 
+# 1021 - https://github.com/JuliaData/CSV.jl/issues/1021
+# user-given types for columns only found later in file
+str = """
+    1 2 3
+    1 2
+    1 2 3 4
+    1
+    1 2 3 4 5
+    """
+f = CSV.File(IOBuffer(str); delim=" ", header=false, types=String)
+@test String <: eltype(f.Column5)
+# case where `types isa AbstractVector`
+f = CSV.File(IOBuffer(str); delim=" ", header=false, types=[Int8, Int16, Int32, Int64, String])
+@test String <: eltype(f.Column5)
+
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -810,8 +810,8 @@ str = """
 f = CSV.File(IOBuffer(str); delim=" ", header=false, types=String)
 @test String <: eltype(f.Column5)
 # case where `types isa AbstractVector`
-f = CSV.File(IOBuffer(str); delim=" ", header=false, types=[Int8, Int16, Int32, Int64, String])
-@test String <: eltype(f.Column5)
+f = CSV.File(IOBuffer(str); delim=" ", header=false, types=[Int8, Int16, Int32, Int64, Int128])
+@test Int128 <: eltype(f.Column5)
 # case where `types isa Function`
 f = CSV.File(IOBuffer(str); delim=" ", header=false, types=(i,nm) -> (i == 5 ? Int8 : String))
 @test Int8 <: eltype(f.Column5)


### PR DESCRIPTION
- close #1021 
- Before this PR, when we encounter a new/extra column we were always relying on type detection -- by setting this extra column's type to `NeedsTypeDetection` -- or, if streaming, setting it to a string type. This meant we were ignoring the case where a user had actually provided the type for this "extra" column, e.g. by setting `types=T`, to request all columns to have eltype `T`.
- This PR largely factors out the Column-type setting logic used when initalising columns in `Context` to be available to be reused by `File` when a new/extra column is encountered during parsing.