### PR TITLE
Clear thread state to ensure threads local state don't keep references

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -283,6 +283,7 @@ function File(ctx::Context, @nospecialize(chunking::Bool=false))
                 Threads.@spawn multithreadpostparse(ctx, ntasks, pertaskcolumns, rows, finalrows, j, col)
             end
         end
+        clear_thread_states()
     else
         # single-threaded parsing
         columns = ctx.columns

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -620,8 +620,16 @@ end
 # as suggested in the above issue, spawned tasks may
 # end up getting stuck in thread local storage
 # running clear_thread_states clears out any thread local storage tasks
+struct _Returns{V} <: Function
+    value::V
+    _Returns{V}(value) where {V} = new{V}(value)
+    _Returns(value) = new{_stable_typeof(value)}(value)
+end
+
+(obj::_Returns)(@nospecialize(args...); @nospecialize(kw...)) = obj.value
+
 function clear_thread_states()
     Threads.@threads :static for _ in 1:Threads.nthreads()
-        Timer(Returns(nothing), 0; interval = 1)
+        Timer(_Returns(nothing), 0; interval = 1)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -622,8 +622,6 @@ end
 # running clear_thread_states clears out any thread local storage tasks
 struct _Returns{V} <: Function
     value::V
-    _Returns{V}(value) where {V} = new{V}(value)
-    _Returns(value) = new{_stable_typeof(value)}(value)
 end
 
 (obj::_Returns)(@nospecialize(args...); @nospecialize(kw...)) = obj.value

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -615,3 +615,13 @@ macro refargs(ex)
         return esc(ex)
     end
 end
+
+# https://github.com/JuliaLang/julia/issues/40626
+# as suggested in the above issue, spawned tasks may
+# end up getting stuck in thread local storage
+# running clear_thread_states clears out any thread local storage tasks
+function clear_thread_states()
+    Threads.@threads :static for _ in 1:Threads.nthreads()
+        Timer(Returns(nothing), 0; interval = 1)
+    end
+end


### PR DESCRIPTION
We're surely running into https://github.com/JuliaLang/julia/issues/40626.

This is my attempt to clear thread's local storage after multithreaded parsing.