### PR TITLE
Disallow delim and quotechar matching

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -76,18 +76,6 @@ f = CSV.File(IOBuffer("a,b\n1,2\n"); limit=0)
 @test f.names == [:a, :b]
 @test f.rows == 0
 
-# delim same as quotechar
-f = CSV.File(IOBuffer("a\"b\n1\"2\n"); delim='"')
-@test f.rows == 0
-@test f.cols == 2
-@test f.types == [Missing, Missing]
-
-# delim same as quotechar w/ quoted field
-f = CSV.File(IOBuffer("a\"b\n1\"\"2\"\n"); delim='"')
-@test f.rows == 0
-@test f.cols == 2
-@test f.types == [Missing, Missing]
-
 # 387
 f = CSV.File(IOBuffer("a,b\n1,1\n1,2\n1,3\n"))
 


### PR DESCRIPTION
Upon review of Parsers.Options validations ([ref](https://github.com/JuliaData/Parsers.jl/pull/152)), @nickrobinson251, @Drvi, and I agree that this shouldn't be valid. The problem is that there's an ambiguity in the case of a _missing_ field vs. an empty quoted field vs. a quoted field with newlines. For example:

```julia
a"b"c
1"2"3   # normal row
"2"3    # 1st field is missing, but ambiguous with 1st field as quoted `"2"`
"1""2"3 # Also ambiguous because the 2nd quote escapes the 3rd, so value is `1"2`
```