### PR TITLE
Fix getproperty calls on fields for File

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -926,7 +926,7 @@ function File(sources::Vector;
     if source !== nothing
         # add file name of each "partition" as 1st column
         pushfirst!(files, f)
-        vals = source isa Pair ? source.second : [f.name for f in files]
+        vals = source isa Pair ? source.second : [getname(f) for f in files]
         pool = Dict(x => UInt32(i) for (i, x) in enumerate(vals))
         arr = PooledArray(PooledArrays.RefArray(ChainedVector([fill(UInt32(i), getrows(f)) for (i, f) in enumerate(files)])), pool)
         col = Column(eltype(arr))
@@ -935,7 +935,7 @@ function File(sources::Vector;
         colnm = Symbol(source isa Pair ? source.first : source)
         push!(getnames(f), colnm)
         push!(gettypes(f), eltype(arr))
-        f.lookup[colnm] = col
+        getlookup(f)[colnm] = col
     end
     return File(getname(f), getnames(f), gettypes(f), rows, getcols(f), getcolumns(f), getlookup(f))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -820,4 +820,9 @@ f = CSV.File(IOBuffer(str); delim=" ", header=false, types=(i,nm) -> (i == 5 ? I
 f = CSV.File(IOBuffer(str); delim=" ", header=false, types=Dict(r".*" => Float16))
 @test Float16 <: eltype(f.Column5)
 
+# 1080
+# bug in reading multiple files when a column shares name with a field in File
+f = CSV.File(map(IOBuffer, ["name\n2\n", "name\n11\n"]))
+@test f.name == [2, 11]
+
 end


### PR DESCRIPTION
Solves #1080 and adds test for the original instance of the problem.

Would it be worth having a check on all field names? Feels like it is very easy to accidentally use the dot syntax internally when accessing the fields, and only when someone use data where the columns share the names something would be incorrect. Maybe more than only this constructor should be tested with columns using the field names of `File`?