### PR TITLE
Fix multithreaded fail on trailing empty column

### DIFF
--- a/test/testfiles.jl
+++ b/test/testfiles.jl
@@ -687,6 +687,11 @@ testfiles = [
         NamedTuple{(:x, :y), Tuple{Int, Int}},
         (x = [15887, 23603], y = [24651, 14076])
     ),
+    ("test_trailing_empty_column.csv", (ntasks=3,),
+        (14,3),
+        NamedTuple{(:X,:Y,:Z), Tuple{Int, Union{Missing,String7}, Union{Missing,Float64}}},
+        nothing
+    )
 ];
 
 @static if VERSION >= v"1.3-DEV"

--- a/test/testfiles/test_trailing_empty_column.csv
+++ b/test/testfiles/test_trailing_empty_column.csv
@@ -1,0 +1,15 @@
+﻿X,Y,Z
+1,aaaa,.1
+2,bbbb,.2
+3,cccc,.3
+4,dddd,.4
+5,eeee,.5
+6,ffff,.6
+7,gggg,.7
+8,hhhh,.8
+9,iiii,.9
+10,jjjj,.10
+11,kkkk,.11
+12,llll,.12
+13,mmmm,.13
+14,,


### PR DESCRIPTION
While looking at https://github.com/JuliaData/CSV.jl/issues/1095 I noticed that multi-threaded parsing currently fails (and falls back to single-thread) when a file ends with a trailing empty column, i.e. a line ending with a column delimiter with no trailing newline. This fixes that.