### PR TITLE
doc(examples.md): fix extraneous ```

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -559,7 +559,6 @@ x y
 
 file = CSV.File(IOBuffer(data); groupmark=',')
 ```
-```
 
 ## [Custom groupmarks](@ref groupmark_example)
 


### PR DESCRIPTION
In the [current documentation](https://csv.juliadata.org/stable/examples.html#decimal_example) the formatting is broken past the "Thousands separator" example thanks to a stray ```` ``` ````.