### PR TITLE
Support arbitrary `DenseVector{UInt8}` as valid sources.

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -65,7 +65,7 @@ const DEFAULT_MAX_INLINE_STRING_LENGTH = 32
 const TRUE_STRINGS = ["true", "True", "TRUE", "T", "1"]
 const FALSE_STRINGS = ["false", "False", "FALSE", "F", "0"]
 const StringCodeUnits = Base.CodeUnits{UInt8, String}
-const ValidSources = Union{Vector{UInt8}, SubArray{UInt8, 1, Vector{UInt8}}, StringCodeUnits, IO, Cmd, AbstractString, AbstractPath}
+const ValidSources = Union{DenseVector{UInt8}, StringCodeUnits, IO, Cmd, AbstractString, AbstractPath}
 const MAX_INPUT_SIZE = Int === Int64 ? 2^42 : typemax(Int32)
 const EMPTY_INT_ARRAY = Int[]
 


### PR DESCRIPTION
The specific motivation of this is so that in Julia 1.11, `Memory` is a valid source, but it does seem reasonable in general.