### PR TITLE
Add compat to Documenter.jl, use `warnonly = Documenter.except()`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(;
     repo="https://github.com/JuliaData/CSV.jl/blob/{commit}{path}#{line}",
     sitename="CSV.jl",
     authors="Jacob Quinn",
+    warnonly = Documenter.except(),
 )
 
 deploydocs(;


### PR DESCRIPTION
that should allow the docs CI to pass.