### PR TITLE
Fix reading gzipped file in Julia 1.11 on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: 'nightly'
+          - os: windows-latest
+            arch: x64
+            version: 'lts'
 
     steps:
       - run: git config --global core.autocrlf false

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -378,21 +378,8 @@ f = CSV.File(IOBuffer("a,b,c\n1,2,3\n\n"))
 f = CSV.File(IOBuffer("zip\n11111-1111\n"), dateformat = "y-m-dTH:M:S.s")
 @test (length(f), length(f.names)) == (1, 1)
 
-# Supporting commands across multiple platforms cribbed from julia/test/spawn.jl
-catcmd = `cat`
-havebb = false
-if Sys.iswindows()
-    busybox = download("https://frippery.org/files/busybox/busybox.exe", joinpath(tempdir(), "busybox.exe"))
-    havebb = try # use busybox-w32 on windows, if available
-        success(`$busybox`)
-        true
-    catch
-        false
-    end
-    if havebb
-        catcmd = `$busybox cat`
-    end
-end
+# `cat` isn't always available on Windows
+catcmd = `$(Base.julia_cmd()) --eval "write(stdout, open(ARGS[1]))"`
 f = CSV.File(`$(catcmd) $(joinpath(dir, "test_basic.csv"))`)
 @test columntable(f) == columntable(CSV.File(joinpath(dir, "test_basic.csv")))
 


### PR DESCRIPTION
Fixes #1137

On Julia 1.11 the underlying memory needs to be finalized to unmmap the file.
Ref: https://github.com/JuliaLang/julia/pull/54210