### PR TITLE
Fix compatibility with Julia 1.13+ memhash removal

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -578,9 +578,11 @@ struct PointerString
     len::Int
 end
 
-function Base.hash(s::PointerString, h::UInt)
-    h += Base.memhash_seed
-    ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), s.ptr, s.len, h % UInt32) + h
+if isdefined(Base, :memhash)
+    function Base.hash(s::PointerString, h::UInt)
+        h += Base.memhash_seed
+        ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), s.ptr, s.len, h % UInt32) + h
+    end
 end
 
 import Base: ==


### PR DESCRIPTION
Remove hash method definition when Base.memhash is not available.
On Julia 1.13+, these AbstractString types will use the default
AbstractString hash implementation which is now efficient and
zero-copy based on codeunit/iterate.

For Julia <1.13, continue using the memhash-based implementation
for compatibility.

Related to JuliaLang/julia#59697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
