### PR TITLE
Fix usage of internal `@check` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CSV"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "0.10.15"
+version = "0.10.16"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/write.jl
+++ b/src/write.jl
@@ -306,6 +306,7 @@ end
 
 macro check(n)
     esc(quote
+        @assert @isdefined(io) "internal error: `io` not defined in scope of `@check` macrocall"
         $n > length(buf) && buffertoosmall(pos + $n - 1, length(buf))
         if (pos + $n - 1) > len
             Base.write(io, view(buf, 1:(pos - 1)))

--- a/src/write.jl
+++ b/src/write.jl
@@ -142,7 +142,7 @@ function Base.iterate(r::RowWriter)
     colnames = isempty(r.header) ? Tables.columnnames(row) : r.header
     pos = 1
     if r.options.bom
-        pos = writebom(r.buf, pos, length(r.buf))
+        pos = writebom(r.buf, pos, length(r.buf), DummyIO())
     end
     cols = length(colnames)
     !r.writeheader && return iterate(r, (state, cols))
@@ -215,7 +215,7 @@ function write(sch::Tables.Schema, rows, file, opts;
     with(file, append, compress) do io
         Base.@_inline_meta
         if !append && opts.bom
-            pos = writebom(buf, pos, len)
+            pos = writebom(buf, pos, len, io)
         end
         if header === true || (header isa Vector && !append)
             pos = writenames(buf, pos, len, io, colnames, cols, opts)
@@ -244,7 +244,7 @@ function write(::Nothing, rows, file, opts;
     if state === nothing
         if header isa Vector && !isempty(header)
             with(file, append, compress) do io
-                !append && opts.bom && (pos = writebom(buf, pos, len) )
+                !append && opts.bom && (pos = writebom(buf, pos, len, io) )
                 pos = writenames(buf, pos, len, io, header, length(header), opts)
                 Base.write(io, resize!(buf, pos - 1))
             end
@@ -257,7 +257,7 @@ function write(::Nothing, rows, file, opts;
     cols = length(names)
     with(file, append, compress) do io
         if !append && opts.bom
-            pos = writebom(buf, pos, len)
+            pos = writebom(buf, pos, len, io)
         end
         if header === true || (header isa Vector && !append)
             pos = writenames(buf, pos, len, io, names, cols, opts)
@@ -315,7 +315,7 @@ macro check(n)
     end)
 end
 
-function writebom(buf, pos, len)
+function writebom(buf, pos, len, io)
     @check 3
     @inbounds buf[pos] = 0xEF
     @inbounds buf[pos+1] = 0xBB

--- a/test/write.jl
+++ b/test/write.jl
@@ -397,4 +397,8 @@ Base.string(x::AF) = string(x.f)
     str = CSV.writerow(row; delim='\t')
     @test str == "1\t2.3\they\t2022-05-04\n"
 
+    # CSV.writebom
+    # https://github.com/JuliaData/CSV.jl/pull/1179
+    @test CSV.writebom(UInt8[1,2,3], 2, 1, IOBuffer()) isa Int
+
 end # @testset "CSV.write"


### PR DESCRIPTION
Fixes an undefvar error (found by JET.jl on a package that calls `CSV.write(file::String, table::NamedTuple)`:
```julia
│││││││││││┌ writebom(buf::Vector{UInt8}, pos::Any, len::Int64) @ CSV ~/.julia/packages/CSV/XLcqT/src/write.jl:306
││││││││││││ `CSV.io` is not defined: CSV.io
```

Repro:
```julia
julia> using CSV; CSV.writebom(UInt8[1,2,3], 2, 1)
ERROR: UndefVarError: `io` not defined
Stacktrace:
 [1] writebom(buf::Vector{UInt8}, pos::Int64, len::Int64)
   @ CSV ~/repos/CSV.jl/src/write.jl:311
 [2] top-level scope
   @ REPL[2]:1
```

the `@check` macro assumes certain variables are in scope, namely `io` (and `buf`, `pos`, `len`), but that wasn't true for `writebom`.

this PR updates `writebom` to take a variable named `io`, and updates `@check` to assert a `io` variable is defined.
the other variables are always referenced in the expanded code, so we don't `@assert @isdefined` those.