### PR TITLE
Fix transposed string promotion

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -11,6 +11,7 @@ Fields:
   * `column`: the actual column vector to hold parsed values; field is typed as `AbstractVector` and while parsing, we do switches on `col.type` to assert the column type to make code concretely typed
   * `lock`: in multithreaded parsing, we have a top-level set of `Vector{Column}`, then each threaded parsing task makes its own copy to parse its own chunk; when synchronizing column types/pooled refs, the task-local `Column` will `lock(col.lock)` to make changes to the parent `Column`; each task-local `Column` shares the same `lock` of the top-level `Column`
   * `position`: for transposed reading, the current column position
+  * `startposition`: for transposed reading, the starting position for this column
   * `endposition`: for transposed reading, the expected ending position for this column
 """
 mutable struct Column
@@ -26,6 +27,7 @@ mutable struct Column
     # per top-level column fields (don't need to copy per task when parsing)
     lock::ReentrantLock
     position::Int
+    startposition::Int
     endposition::Int
     options::Parsers.Options
 
@@ -485,6 +487,7 @@ end
         for i = 1:ncols
             col = columns[i]
             col.position = positions[i]
+            col.startposition = positions[i]
             col.endposition = endpositions[i]
         end
     end

--- a/src/file.jl
+++ b/src/file.jl
@@ -889,6 +889,13 @@ end
 
 @noinline function promotetostring!(ctx::Context, buf, pos, len, rowsguess, rowoffset, columns, ::Type{customtypes}, column_to_promote, numwarnings, limit, stringtype) where {customtypes}
     cols = [i == column_to_promote ? columns[i] : Column(Missing, columns[i].options) for i = 1:length(columns)]
+    if ctx.transpose
+        for (col, source) in zip(cols, columns)
+            col.position = source.startposition
+            col.startposition = source.startposition
+            col.endposition = source.endposition
+        end
+    end
     col = cols[column_to_promote]
     col.column = allocate(stringtype, rowsguess)
     col.type = stringtype
@@ -898,7 +905,7 @@ end
         while row < limit
             row += 1
             @inbounds pos = parserow(startpos, row, numwarnings, ctx, buf, pos, len, rowsguess, rowoffset, cols, customtypes)
-            pos > len && break
+            (ctx.transpose ? all(c -> c.position >= c.endposition, cols) : pos > len) && break
         end
     end
     return

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -317,6 +317,45 @@ f = CSV.File(IOBuffer(""), transpose=true, header=false)
 f = CSV.File(IOBuffer(""), transpose=true, header=Symbol[])
 @test (length(f), length(f.names)) == (0, 0)
 
+@testset "transpose string promotion (#1172)" begin
+    normalize(x) = map(y -> ismissing(y) ? missing : string(y), x)
+    expected_a = [missing, "1", "x", "3"]
+    expected_b = [missing, 4, 5, 6]
+
+    for value in ("x", "\"x\"")
+        source = "a,,1,$value,3\nb,,4,5,6"
+        f = CSV.File(IOBuffer(source); transpose=true)
+        @test isequal(normalize(f.a), expected_a)
+        @test isequal(f.b, expected_b)
+    end
+
+    source = "a,,1,\"x\",3\nb,,4,5,6"
+    table = CSV.read(IOBuffer(source), Tables.columntable; transpose=true)
+    @test isequal(normalize(table.a), expected_a)
+    @test isequal(table.b, expected_b)
+
+    rows = Tables.rowtable(CSV.Rows(IOBuffer(source); transpose=true))
+    @test isequal([ismissing(row.a) ? missing : string(row.a) for row in rows], expected_a)
+    @test isequal([ismissing(row.b) ? missing : string(row.b) for row in rows],
+        [missing, "4", "5", "6"])
+
+    f = CSV.File(IOBuffer("skip,a,,1,x,3\nskip,b,,4,5,6"); transpose=true, header=2)
+    @test isequal(normalize(f.a), expected_a)
+    @test isequal(f.b, expected_b)
+
+    f = CSV.File(IOBuffer(",1,x,3\n,4,5,6"); transpose=true, header=[:a, :b])
+    @test isequal(normalize(f.a), expected_a)
+    @test isequal(f.b, expected_b)
+
+    f = CSV.File(IOBuffer(source); transpose=true, limit=3)
+    @test isequal(normalize(f.a), expected_a[1:3])
+    @test isequal(f.b, expected_b[1:3])
+
+    f = CSV.File(IOBuffer("a,,1,x,3\nb,4"); transpose=true)
+    @test isequal(normalize(f.a), expected_a)
+    @test isequal(f.b, [4, missing, missing, missing])
+end
+
 # providing empty header vector
 f = CSV.File(IOBuffer("x\nabc\n"), header=Symbol[])
 @test f.names == [:Column1]


### PR DESCRIPTION
Fixes #1172.

When a transposed column promoted to string, reparsing reused advanced or uninitialized column positions, shifting data and sometimes crashing.

Save each transposed column's starting position and restore all positions during promotion reparsing. The reparse now also stops using each column's own end position. Regression tests cover the affected APIs and edge cases.

Tests: `JULIA_NUM_THREADS=4 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` (1,497 passed)

Co-authored by Codex