### PR TITLE
Keep source column when sources vector has one file

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -912,7 +912,7 @@ function File(sources::Vector;
     if source isa Pair
         length(source.second) == length(sources) || throw(ArgumentError("source pair keyword argument list ($(length(source.second))) must match length of input vector ($(length(sources)))"))
     end
-    length(sources) == 1 && return File(sources[1]; kw...)
+    source === nothing && length(sources) == 1 && return File(sources[1]; kw...)
     all(x -> x isa ValidSources, sources) || throw(ArgumentError("all provided sources must be one of: `$ValidSources`"))
     kws = merge(values(kw), (ntasks=1,))
     f = File(sources[1]; kws...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -520,6 +520,25 @@ f = CSV.File(map(IOBuffer, data); source=:source=>["1", "2", "3"])
 @test eltype(f.source) == String
 @test f.source isa PooledArray
 
+# single-element source vector keeps the source column (#1146)
+onefile = tempname() * ".csv"
+write(onefile, "a,b,c\n1,2,3\n4,5,6\n")
+
+f = CSV.File([onefile]; source=:source)
+@test :source in propertynames(f)
+@test f.source isa PooledArray
+@test all(==(onefile), f.source)
+
+f = CSV.File([onefile]; source="src")
+@test :src in propertynames(f)
+
+f = CSV.File([onefile]; source=:src=>["tag"])
+@test f.src == ["tag", "tag"]
+
+f = CSV.File([onefile])
+@test :source ∉ propertynames(f)
+@test propertynames(f) == propertynames(CSV.File(onefile))
+
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -521,23 +521,25 @@ f = CSV.File(map(IOBuffer, data); source=:source=>["1", "2", "3"])
 @test f.source isa PooledArray
 
 # single-element source vector keeps the source column (#1146)
-onefile = tempname() * ".csv"
-write(onefile, "a,b,c\n1,2,3\n4,5,6\n")
+mktempdir() do dir
+    onefile = joinpath(dir, "one.csv")
+    write(onefile, "a,b,c\n1,2,3\n4,5,6\n")
 
-f = CSV.File([onefile]; source=:source)
-@test :source in propertynames(f)
-@test f.source isa PooledArray
-@test all(==(onefile), f.source)
+    f = CSV.File([onefile]; source=:source)
+    @test :source in propertynames(f)
+    @test f.source isa PooledArray
+    @test all(==(onefile), f.source)
 
-f = CSV.File([onefile]; source="src")
-@test :src in propertynames(f)
+    f = CSV.File([onefile]; source="src")
+    @test :src in propertynames(f)
 
-f = CSV.File([onefile]; source=:src=>["tag"])
-@test f.src == ["tag", "tag"]
+    f = CSV.File([onefile]; source=:src=>["tag"])
+    @test f.src == ["tag", "tag"]
 
-f = CSV.File([onefile])
-@test :source ∉ propertynames(f)
-@test propertynames(f) == propertynames(CSV.File(onefile))
+    f = CSV.File([onefile])
+    @test :source ∉ propertynames(f)
+    @test propertynames(f) == propertynames(CSV.File(onefile))
+end
 
 end
 


### PR DESCRIPTION
`File(sources::Vector; source=...)` short-circuits a one-element vector to
`File(sources[1]; kw...)`, forwarding only `kw...`. The `source` keyword is bound
to its own parameter, so it is not part of `kw` and gets dropped - a single-element
`sources` vector silently loses the requested source column, while the source-column
injection only runs in the multi-source path.

Skip the short-circuit when `source` is set, so a one-element vector falls through
to the general path that adds the column. The `source === nothing` fast path is
unchanged.

Added regression tests for a single-element `sources` vector: the `source` column
is present with `Symbol`/`String`/`Pair` names, and the no-`source` case still
matches the scalar `CSV.File(path)` result.

Fixes #1146
