### PR TITLE
Warn on short final rows

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -678,13 +678,12 @@ Base.@propagate_inbounds function parserow(startpos, row, numwarnings, ctx::Cont
         else
             if i < ncols
                 if Parsers.newline(code) || pos > len
-                    # in https://github.com/JuliaData/CSV.jl/issues/948,
-                    # it was noticed that if we reached the EOF right before parsing
-                    # the last expected column, then the warning is a bit spurious.
-                    # The final value is `missing` and the csv writer chose to just
-                    # "close" the file w/o including a final newline
-                    # we can treat this special-case as "valid" and not emit a warning
-                    if !(pos > len && i == (ncols - 1))
+                    # In https://github.com/JuliaData/CSV.jl/issues/948,
+                    # the delimiter for an empty final field was the final byte of
+                    # the input. Treat that explicit empty field as valid even
+                    # without a trailing newline, but still warn if the row ended
+                    # before the final field's delimiter was present.
+                    if !(pos > len && i == (ncols - 1) && Parsers.delimited(code))
                         ctx.silencewarnings || numwarnings[] > ctx.maxwarnings || notenoughcolumns(i, ncols, rowoffset + row)
                         !ctx.silencewarnings && numwarnings[] == ctx.maxwarnings && toomanywwarnings()
                         numwarnings[] += 1

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -804,9 +804,15 @@ f = CSV.File(IOBuffer(data); header=false, types=Dict(1 => String), typemap=Dict
 @test f.types == [i == 1 ? String : Int8 for i = 1:60_000]
 
 # 948
-f = CSV.File(IOBuffer("a,b\n1,2\n3,"))
+f = @test_logs CSV.File(IOBuffer("a,b\n1,2\n3,"))
 @test f.a == [1, 3]
 @test isequal(f.b, [2, missing])
+
+# 1190
+for source in ("a,b,c\n1,2,3\n4,5", "a,b,c\n1,2,3\n4,5\n")
+    f = @test_logs (:warn, r"only found 2 / 3 columns around data row: 2") CSV.File(IOBuffer(source))
+    @test isequal(f.c, [3, missing])
+end
 
 # duplicate column names
 f = CSV.File(IOBuffer("a,a,a\n"))


### PR DESCRIPTION
## Summary

- Warn when the final record ends before its last expected field.
- Keep explicit empty final fields warning-free, including without a final newline.
- Add regression coverage for both EOF forms.

Fixes #1190.

## Root cause

The EOF exception added for #948 suppressed the short-row warning whenever parsing passed the end of the input after the penultimate field. That condition did not distinguish these two records:

- `31,32`: only two fields exist under a three-column schema.
- `31,32,`: the delimiter explicitly introduces an empty third field.

The parser return code already records this distinction. The fix now requires `Parsers.delimited(code)` before it suppresses the warning.

## Behavior

- `CSV.Rows`, `CSV.File`, and `CSV.read` now warn for a short final row.
- Inputs with and without a final newline behave the same.
- Quoted and multiline-quoted fields use the same rule.
- The existing #948 trailing-delimiter behavior remains unchanged.
- Parsed values and types do not change. CSV.jl still fills the absent field with `missing`.
- `strict`, `silencewarnings`, and `maxwarnings` keep their existing behavior.

## Compatibility and performance

Callers that relied on a malformed final row being silent can now receive one additional warning. `silencewarnings` and `maxwarnings` still control that warning.

The parser adds one bitmask check only in the early-row-termination branch. It adds no allocation, scan, or reparse.

## Validation

- Julia 1.12.6 with `--startup-file=no`.
- Focused cross-API regression on the rebased head: 21/21 passed.
- Full CSV.jl suite before the conflict-free rebase: 1,486/1,486 passed.
- Final diff check: clean.

Co-authored by Codex
