### PR TITLE
test: move test-only artifacts to `test/Artifacts.toml`

### DIFF
--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,5 +1,6 @@
 [testfiles]
 git-tree-sha1 = "d24c9e978a3e64af0d80251ca2ac49388d942e9d"
+lazy = true
 
     [[testfiles.download]]
     url = "https://github.com/JuliaData/CSV.jl/releases/download/testdata-full-1/testfiles-artifact.tar.gz"

--- a/test/README.md
+++ b/test/README.md
@@ -17,6 +17,6 @@ CSV.jl’s test fixtures live in an artifact (`artifact"testfiles"`) to avoid sh
    archive_artifact(artifact_hash, tarball)
    println((; artifact_hash, sha256=bytes2hex(open(sha256, tarball))))
    ```
-4. Upload the new tarball to a release (same repo/tag is fine), update `Artifacts.toml` with the new `git-tree-sha1` and `sha256`, and keep the asset available so tests can download it.
+4. Upload the new tarball to a release (same repo/tag is fine), update `test/Artifacts.toml` with the new `git-tree-sha1` and `sha256`, and keep the asset available so tests can download it.
 
 Tests assume the artifact root contains the contents of the old `test/testfiles` directory (no extra nesting).


### PR DESCRIPTION
This saves ~30 MB of artifacts in PackageCompiler (and JuliaC) projects that use `CSV.jl`

Resolves https://github.com/JuliaData/CSV.jl/issues/1180